### PR TITLE
docs: key-management, witness-log, migration-and-versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The goal: become the standard envelope format for AI agent events — a record a
 - [`docs/`](docs/) — non-normative design notes for implementers
   - [`throughput-and-trust.md`](docs/throughput-and-trust.md) — submission patterns, trust properties, SDK guidance
   - [`external-anchoring.md`](docs/external-anchoring.md) — using OpenTimestamps (and alternatives) to anchor passports at creation time
+  - [`key-management.md`](docs/key-management.md) — file-based, PKI/X.509, and DID-based signing key patterns
+  - [`witness-log.md`](docs/witness-log.md) — operator architecture for publishing public, anchored checkpoint chains
+  - [`migration-and-versioning.md`](docs/migration-and-versioning.md) — minor vs. major versions, cross-version compatibility, upgrade playbook
 - [`proposals/`](proposals/) — draft proposals
   - [`context-passport-for-mcp.md`](proposals/context-passport-for-mcp.md) — MCP extension proposal
 - [`EXTENSIONS.md`](EXTENSIONS.md) — vendor-namespaced extension registry

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -1,0 +1,393 @@
+# Key Management
+
+**Status:** Non-normative design note
+**Audience:** SDK implementers, security architects, operators of signed-passport pipelines
+**Companion to:** [SPEC.md §3.2.7 — Signature](../SPEC.md#327-signature-optional), [SPEC.md §5.3 — Agent identity](../SPEC.md#53-agent-identity)
+
+---
+
+## Why this document exists
+
+The Context Passport specification defines the `signature` block (SPEC.md §3.2.7) but is deliberately silent on how clients obtain, store, rotate, and revoke the keys used to produce those signatures. That silence is correct — key management is a deep field with many valid patterns and no universal answer. But it leaves implementers with the practical question: *what should I actually do?*
+
+This document describes three patterns the maintainers have seen work in practice, with concrete guidance on when to use each. None are normative. An implementation may choose any approach that produces verifiable signatures over canonical envelopes.
+
+---
+
+## 1. The three patterns
+
+| Pattern | Key location | Identity proof | When to use |
+|---|---|---|---|
+| File-based | Local keyfile or env var | Implicit (operator vouches) | Solo dev, single-tenant prototypes, fixed-agent deployments |
+| PKI / X.509 | Hardware token, HSM, KMS | X.509 certificate chain | Enterprise environments with existing PKI |
+| DID-based | DID document at a resolvable URL | DID document signed by a public key | Multi-party agent ecosystems, cross-organization workflows |
+
+These are not mutually exclusive. A production deployment can have file-based keys for development, PKI keys for staging, and DID-based identity for production agents — the spec doesn't care which is in use at signing time, only that the resulting signature verifies against the embedded public key.
+
+---
+
+## 2. File-based keys
+
+The simplest pattern. A keypair is generated once and persisted to a file readable only by the agent's process.
+
+### Generation
+
+```python
+from context_passport.signing import generate_keypair, public_key_to_base64
+from cryptography.hazmat.primitives import serialization
+
+private, public = generate_keypair()
+
+# Persist private key (PEM-encoded, encrypted with a passphrase)
+with open("agent-key.pem", "wb") as f:
+    f.write(private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(b"passphrase-from-secret-store"),
+    ))
+
+# The public key (base64, raw 32 bytes) is what goes into passport.signature.public_key
+print("public_key:", public_key_to_base64(public))
+```
+
+### Loading at signing time
+
+```python
+from cryptography.hazmat.primitives import serialization
+from context_passport.signing import sign_passport
+
+with open("agent-key.pem", "rb") as f:
+    private = serialization.load_pem_private_key(f.read(), password=b"passphrase-from-secret-store")
+
+signed = sign_passport(passport, private, key_id="agent-key-2026-05")
+```
+
+### Operational rules
+
+- **Never check keyfiles into version control.** Use `.gitignore` plus repository-level secret scanning.
+- **Store the passphrase in a real secret manager** — environment variable injected from AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, 1Password CLI, etc. Never hardcode.
+- **Lock down file permissions** — `chmod 400 agent-key.pem`. On Windows, restrict ACL to the service account that runs the agent.
+- **Rotate annually at minimum**, or whenever the operator who knows the passphrase leaves the team. See §5.
+
+### When file-based breaks down
+
+- More than one agent process needs the same key. Now you have a secrets-distribution problem.
+- The key is needed inside an environment where you don't control filesystem access (some serverless platforms, sandboxed compute).
+- A regulator requires that key material be held in a certified module (FIPS 140-2 Level 3 or similar).
+
+For any of those, move to §3 or §4.
+
+---
+
+## 3. PKI / X.509-based keys
+
+Used by organizations with an existing internal certificate authority or a relationship with a commercial CA. The signing key lives in an HSM, a YubiKey, or a cloud KMS; the public key is wrapped in an X.509 certificate that chains to a trusted root.
+
+### Why this pattern
+
+- Key material never leaves the secure enclave. The agent process calls `sign(bytes)` and receives a signature; the private key bytes are never seen.
+- Identity verification is built in — the X.509 chain provides agent identity (subject DN), validity period (notBefore/notAfter), and revocation status (CRL/OCSP).
+- Compliance teams already understand this model. PKI has been the audited backbone of enterprise authentication for decades.
+
+### Adapting to Context Passport
+
+Context Passport's `signature` block expects an Ed25519, ECDSA-P256, or RSA-PSS-SHA256 signature with a raw public key. X.509 wraps an RSA or EC key with metadata. Two integration patterns:
+
+**Pattern A — pass the raw public key, store the cert separately.**
+
+```python
+# At signing time
+cert = load_x509_cert("/etc/agent-certs/agent.pem")
+raw_public_key = cert.public_key()
+# Use signing.sign_passport() with algorithm matching the cert's key type
+```
+
+The passport contains the raw public key. The X.509 certificate is stored alongside the passport for verifiers who want to see the chain. A namespaced extension MAY record the cert location:
+
+```json
+{
+  "...": "...",
+  "x509.cert_uri": "https://certs.example.com/agents/agent-2026-05.pem",
+  "x509.subject":  "CN=research-agent-01,OU=AI,O=Example,C=US"
+}
+```
+
+**Pattern B — embed the full cert chain in the signature block.**
+
+This makes each passport self-contained but bloats every record. Practical only when individual passports are exchanged out-of-band (e.g., a single high-stakes record sent to a regulator).
+
+```json
+{
+  "signature": {
+    "algorithm":  "ecdsa-p256",
+    "key_id":     "agent-2026-05",
+    "public_key": "<base64 raw key>",
+    "signature":  "<base64 signature>",
+    "x509.chain": ["<base64 cert>", "<base64 intermediate>", "<base64 root>"]
+  }
+}
+```
+
+The `x509.chain` field is a namespaced extension — verifiers that don't understand it ignore it (per the extension model, EXTENSIONS.md). Verifiers that do, validate the chain in addition to the raw signature.
+
+### Key storage backends
+
+| Backend | Cost | Best for |
+|---|---|---|
+| AWS KMS / GCP KMS / Azure Key Vault | $1-$3/key/month | Cloud-native workloads. Key never leaves the KMS. |
+| YubiKey or other USB HSM | One-time hardware cost | Solo developers needing FIPS-grade key storage |
+| Network HSM (Thales Luna, AWS CloudHSM) | $$$ | Regulated industries with FIPS 140-2 Level 3 requirements |
+| Software keystore (PKCS#11 token) | Free | When the OS provides one (macOS Keychain, Windows Credential Store) |
+
+The signing API in each case looks the same to the Context Passport SDK — the SDK calls a `sign(bytes)` function; the backend handles where the key actually lives.
+
+### When PKI breaks down
+
+- Multi-organization workflows where no shared CA exists. Two parties cannot agree on a root.
+- Highly dynamic agents (created and destroyed in seconds) where issuing an X.509 cert per agent is operational overhead.
+- Public agent ecosystems where identity needs to be globally resolvable, not chain-trusted.
+
+For these, move to §4.
+
+---
+
+## 4. DID-based identity
+
+[W3C Decentralized Identifiers](https://www.w3.org/TR/did-core/) (DIDs) decouple identity from any single authority. An agent has a DID like `did:web:example.com:agents:research-01`. The DID resolves (via HTTP for `did:web`, via a registry for `did:key`, `did:ion`, etc.) to a DID Document containing the agent's current public keys.
+
+### Why this pattern
+
+- No central CA. Identity is resolvable by anyone with the DID and an internet connection.
+- Key rotation is built-in — the DID stays stable while the keys in the DID Document change.
+- Cross-organization workflows work without trust agreements at the CA level.
+- The DID can carry rich metadata: agent type, capabilities, service endpoints, controllers.
+
+### Adapting to Context Passport
+
+The passport's `created_by.agent_id` is set to the DID:
+
+```json
+{
+  "created_by": {
+    "agent_id":   "did:web:example.com:agents:research-01",
+    "agent_name": "Research Agent",
+    "role":       "researcher",
+    "provider":   "anthropic",
+    "model":      "claude-opus-4-6"
+  }
+}
+```
+
+The `signature` block carries the verification key:
+
+```json
+{
+  "signature": {
+    "algorithm":   "ed25519",
+    "key_id":      "did:web:example.com:agents:research-01#key-2026-05",
+    "public_key":  "<base64 raw key>",
+    "signature":   "<base64 signature>"
+  }
+}
+```
+
+The `key_id` uses the DID URL syntax: `<did>#<key-fragment>`. A verifier:
+
+1. Reads `signature.key_id`, parses out the DID.
+2. Resolves the DID to its DID Document.
+3. Looks up the key fragment in the DID Document's `verificationMethod` array.
+4. Compares the resolved public key with `signature.public_key`. If they match, the binding is verified.
+5. Verifies the signature with the public key.
+
+If steps 4 or 5 fail, the passport is not trustworthy regardless of how the integrity chain checks out.
+
+### `did:web` is the recommended starting point
+
+Of the dozens of DID methods, `did:web` is the practical choice for almost all Context Passport users:
+
+- No blockchain dependency.
+- The DID Document is just a JSON file hosted at a well-known URL: `https://example.com/.well-known/did.json` (for `did:web:example.com`).
+- Rotation = update the JSON file.
+- Revocation = remove the key from the JSON file (or remove the entire DID Document).
+- Identity is tied to a domain you already control.
+
+A minimal DID Document for an agent:
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:web:example.com:agents:research-01",
+  "verificationMethod": [{
+    "id":                 "did:web:example.com:agents:research-01#key-2026-05",
+    "type":               "Ed25519VerificationKey2020",
+    "controller":         "did:web:example.com:agents:research-01",
+    "publicKeyMultibase": "z6Mk..."
+  }],
+  "assertionMethod": ["did:web:example.com:agents:research-01#key-2026-05"]
+}
+```
+
+Hosted at `https://example.com/agents/research-01/did.json`. The DID resolver fetches that URL when asked to resolve `did:web:example.com:agents:research-01`.
+
+### When DID-based breaks down
+
+- Air-gapped environments where DID resolution requires network access verifiers don't have.
+- Highly regulated environments where the regulator does not yet accept DIDs as identity evidence.
+
+In either case, fall back to PKI (§3) or operate the DID Document on an internal-only domain that the regulator can resolve.
+
+---
+
+## 5. Key rotation
+
+Rotation is the act of replacing the active signing key while keeping the agent's identity stable. Three rotation patterns, in order of common preference:
+
+### 5.1 Hard cutover
+
+At time T:
+1. Generate new key.
+2. Publish new public key (in the DID Document, or in the KMS, or in the keyfile path agents read).
+3. From T forward, all new passports are signed with the new key.
+4. Old passports remain verifiable because the old public key is embedded in each passport's `signature.public_key`.
+
+Simplest. Used by most production agents. Requires no special infrastructure beyond "make the new key available to the signing process."
+
+### 5.2 Overlap window
+
+At time T0, both old and new keys are active. The agent signs with the new key but the old key remains valid for verification. At time T1 (typically T0 + days/weeks), the old key is deactivated.
+
+Useful when:
+- Different agents in a fleet roll over at different times.
+- Verifiers cache key material and need time to refresh.
+- A bad rotation needs to be quickly reversed.
+
+In a DID-based model: both keys appear in the DID Document's `verificationMethod` array during the overlap window. In a file-based model: the agent reads both keyfiles and uses the newer one for new signatures while keeping the old one resolvable.
+
+### 5.3 Forward-secret rotation
+
+A new key per passport (or per session). The current public key is published; previous keys are not retained. Maximum security; only used when extreme compromise resistance is needed and the operational cost is acceptable.
+
+Rarely the right tradeoff for Context Passport — the passport itself carries the public key, so per-passport keys produce verifiable records, but verifying retrospectively requires retrieving each per-passport key from somewhere.
+
+### Recommendation
+
+For most deployments: **annual hard cutover, with monthly overlap windows during the rotation event**. Schedule the rotation; announce it; execute. Aligns with most compliance frameworks' key-rotation expectations.
+
+---
+
+## 6. Key revocation
+
+Revocation is the act of declaring a previously-valid key no longer trusted. Distinct from rotation: rotation says "use this new key going forward," revocation says "do not trust anything signed by that key, including past records."
+
+Context Passport does not have a native revocation mechanism (a passport signed with a revoked key still verifies cryptographically; the spec leaves revocation to the identity layer). Three patterns:
+
+### 6.1 DID Document removal
+
+Remove the key from the DID Document's `verificationMethod` array. Verifiers who resolve the DID will not find the key, and verification fails at the binding step (step 4 in §4).
+
+This is *prospective* — verifiers caching the old DID Document still verify the signature until their cache expires. Use short TTLs (`Cache-Control: max-age=300` on the DID Document JSON) if revocation timeliness matters.
+
+### 6.2 X.509 CRL / OCSP
+
+The X.509 ecosystem already has Certificate Revocation Lists and Online Certificate Status Protocol. Verifiers check revocation status at verification time. Adds latency to verification (one extra HTTP call) but is well-understood.
+
+Useful when the certs are issued by a CA that publishes a CRL.
+
+### 6.3 Revocation extension field
+
+A namespaced extension carrying the URL of a public revocation list maintained by the operator:
+
+```json
+{
+  "signature": {
+    "...": "...",
+    "revocation.list_uri": "https://example.com/.well-known/cp-revoked-keys.json"
+  }
+}
+```
+
+The verifier fetches the list and checks whether `signature.key_id` appears in it. If yes, verification fails regardless of cryptographic validity.
+
+This is implementation-specific and not part of the spec. The pattern is documented here so multiple implementations can converge on the same extension name if useful.
+
+### Revocation does not invalidate the chain
+
+A revoked key does not retroactively invalidate the hash chain. Other passports in the chain remain verifiable. What revocation does is invalidate trust in the signer's attestation — the record "exists" and "was created at a specific time" remain provable; "was authorized by this agent" no longer is.
+
+---
+
+## 7. Multi-agent and multi-key scenarios
+
+### Per-agent keys
+
+Each agent in a multi-agent system has its own keypair. The chain of passports across the system contains signatures from multiple agents, each with their own `signature.key_id`. Verifiers process each passport with its embedded public key.
+
+This is the default and recommended pattern. It localizes compromise (one agent's key compromised doesn't affect others), it scales (no shared key to rotate), and it matches the natural identity model (one agent = one identity).
+
+### Per-key-per-agent rotation
+
+A single agent over time has multiple keys (key-2026-04, key-2026-05, etc.) as it rotates. Each passport embeds the key that signed it. Verifiers do not need to know about the agent's full key history — the passport carries everything they need.
+
+### Shared keys across agents
+
+Anti-pattern in most contexts. If multiple agents share a key:
+- Compromise of one agent compromises all
+- Attribution is impossible (which agent actually signed?)
+- Rotation requires coordinated update across all agents
+
+Only acceptable when the agents are functionally one process (e.g., a horizontally-scaled stateless worker pool where every worker is interchangeable).
+
+### Operator-signed vs. agent-signed
+
+Two interpretations of "the signer":
+
+- **Agent-signed:** the AI agent itself has a key. Most secure attribution.
+- **Operator-signed:** the operator's signing infrastructure signs on behalf of the agent. Easier to centralize key management; loses some of the "what the agent actually said" property.
+
+Both produce valid Context Passports. The choice depends on threat model: do you need to prove the agent itself produced the record, or is "the operator vouches that this is what the agent produced" sufficient?
+
+---
+
+## 8. Threat model and what signing actually prevents
+
+Signing is necessary for some properties and irrelevant to others. To set expectations:
+
+**Signing prevents:**
+- Modification of the envelope after creation (modification breaks the signature)
+- Forgery of records by parties without the private key
+- Repudiation by the signer ("I never signed this") — the signature is non-repudiable
+
+**Signing does not prevent:**
+- Omission of records the signer chose not to create
+- Backdating — the signer can set `event.timestamp` to any value before signing (see external-anchoring.md)
+- A malicious operator who controls both the agent and the signing key from producing whatever record they want
+- A compromised key from signing fraudulent records
+
+Threat models that require defense against the last two require either: (a) HSM-bound keys the operator cannot extract, (b) multi-party signing (M-of-N), or (c) auxiliary attestation from a non-collaborating party.
+
+The spec deliberately does not address (a)-(c). Implementations can layer them on without modifying the wire format.
+
+---
+
+## 9. Recommended pattern by deployment context
+
+| Context | Pattern | Key storage | Rotation cadence |
+|---|---|---|---|
+| Solo developer prototype | File-based | Local keyfile + passphrase in env var | Manual, when needed |
+| Single-tenant production agent | File-based or KMS | Cloud KMS | Annual |
+| Multi-agent within one org | Per-agent file-based or KMS | KMS recommended | Annual |
+| Enterprise with PKI | X.509 | HSM or CloudHSM | Per cert validity (1-3 years) |
+| Multi-org agent ecosystem | DID-based (`did:web`) | KMS holds key, DID Document points to it | Per-key annually |
+| Public ecosystem / standards play | DID-based, multiple key methods | Whatever the ecosystem agrees on | Per DID Document policy |
+
+---
+
+## 10. What this document does not cover
+
+- **Specific HSM vendor integration.** Each vendor has its own SDK. The Context Passport SDK should expose a `sign(bytes) -> bytes` callback that operators wire to whatever signing backend they use.
+- **Multi-party signing (threshold/MPC).** Possible but not standardized for Context Passport. The signature block as defined assumes a single signer. Implementations can use namespaced extensions to carry multi-party metadata.
+- **Post-quantum migration.** Ed25519 and ECDSA are not post-quantum secure. When NIST-standardized post-quantum signatures (ML-DSA, SLH-DSA) become widely available, a future major version of the spec may add them as supported `algorithm` values. Until then, accept the assumption that quantum-relevant adversaries are not in the threat model.
+
+---
+
+*Context Passport — design notes for implementers. Released under CC0 along with the rest of the specification.*

--- a/docs/migration-and-versioning.md
+++ b/docs/migration-and-versioning.md
@@ -1,0 +1,330 @@
+# Migration and Versioning
+
+**Status:** Non-normative design note
+**Audience:** SDK implementers, operators planning multi-year deployments, anyone integrating with multiple Context Passport implementations
+**Companion to:** [SPEC.md §2.4 — Versioned from the first release](../SPEC.md#24-versioned-from-the-first-release), [SPEC.md §2.6 — Forward-compatible by extension](../SPEC.md#26-forward-compatible-by-extension), [GOVERNANCE.md](../GOVERNANCE.md)
+
+---
+
+## Why this document exists
+
+A standard that doesn't tell implementers what to do with old and new records becomes a fork generator. Two implementations both claim "Context Passport conformance"; one of them sees a passport with a field it doesn't recognize; what should it do? Reject? Strip the field? Pass it through? Each choice produces a different downstream behavior, and the absence of a documented answer means implementations diverge.
+
+This document specifies the versioning model, the contract between major versions, and the playbook for migrating records, chains, and pipelines as the spec evolves.
+
+---
+
+## 1. Versioning model
+
+Context Passport uses **semantic versioning at the major-version boundary**:
+
+- **Patch versions** (`1.0.0` → `1.0.1`): editorial only. Typo fixes, clarifications, better examples. No behavior change. Implementations do not need to be aware of patch versions.
+- **Minor versions** (`1.0` → `1.1`): additive only. New optional fields, new event types in the registry, new namespaced extensions promoted to core. All v1.0 passports remain valid v1.1 passports. All v1.1 implementations can consume v1.0 passports.
+- **Major versions** (`1.x` → `2.0`): may include breaking changes. New required fields, removed fields, changed semantics, changed hash construction, changed signature canonicalization. Implementations of v2.0 are not required to consume v1.x passports natively (though they are encouraged to via a separate compatibility module).
+
+The `schema_version` field in the passport envelope (SPEC.md §3.2.1) carries the version of the spec the passport was produced against. **`schema_version` MUST match `major.minor`** — patch versions are not reflected.
+
+Examples:
+- `"1.0"` — produced against v1.0
+- `"1.1"` — produced against v1.1 (when it ships)
+- `"2.0"` — produced against v2.0
+
+---
+
+## 2. What can change in a minor version
+
+A minor version (`1.0` → `1.1`) may add:
+
+- **New optional fields** in the envelope or in any sub-object (`created_by`, `event`, `integrity`, `lineage`, `signature`).
+- **New values in open enums** like `event.type`, `created_by.provider`, `created_by.role`. These were always documented as "examples, custom values permitted" — new defaults entering the registry is purely additive.
+- **New namespaced extensions promoted to core.** A field that lived in `EXTENSIONS.md` for at least six months with three independent implementations (per `EXTENSIONS.md`) may be promoted to a core field. The namespaced version remains valid as an alias for one full major version.
+- **Stricter validation rules that loosen, not tighten.** Example: accepting additional date-time formats in `event.timestamp`.
+- **New conformance levels** layered on top of existing ones. The Signed conformance level (introduced after the spec's initial draft) is an example.
+
+A minor version may NOT:
+
+- Add new required fields. An old client producing a v1.0 passport must still produce a passport that validates under v1.1.
+- Remove or rename existing fields.
+- Change the canonical-JSON algorithm or hash function.
+- Change how `integrity_hash` is computed.
+- Change how `signature.signature` is computed.
+
+If any of these are needed, a major version is required.
+
+---
+
+## 3. What can change in a major version
+
+A major version (`1.x` → `2.0`) may include any of the above plus:
+
+- **New required fields.** Records emitted under v2.0 may be required to carry fields v1.x records did not have.
+- **Removed fields.** A v1.x field may be deprecated and removed in v2.0.
+- **Changed semantics.** A field's meaning may shift. (Rare in practice; usually preferred to rename and deprecate the old name.)
+- **Changed canonical-JSON algorithm.** Unlikely but permitted. Would invalidate the hash chain across the version boundary.
+- **New hash function.** Replacing SHA-256 with SHA-3 or BLAKE3 would require a major version.
+- **New signature canonicalization.** The "signature over canonical envelope with signature.signature cleared" rule (SPEC.md §3.2.7) could be replaced with a different canonical-bytes definition.
+
+Major version changes require:
+
+- A formal RFC process per `GOVERNANCE.md`.
+- A published migration guide (this document is the template).
+- A reference migration tool in the official Python and TypeScript implementations.
+- At least six months between the v2.0-draft tag and v2.0-final.
+
+---
+
+## 4. How implementations handle records from other versions
+
+The contract between implementations and records, by version relationship:
+
+### 4.1 Implementation version matches record version
+
+The default case. Validate, verify, process normally.
+
+### 4.2 Implementation is NEWER than record (e.g. impl is v1.2, record is v1.0)
+
+**Required behavior:** accept. Any v1.x implementation MUST consume any v1.y passport where y ≤ current major. Backward compatibility within a major version is non-negotiable — this is the central promise of minor versioning.
+
+Implementation details:
+- Fields added in v1.1+ are simply absent on the v1.0 record. Treat as null/missing.
+- Fields whose validation loosened in later minor versions: apply the loosened validation.
+- Conformance level claims: the implementation may still claim its own conformance level. Whether the v1.0 record was created by a conformant v1.0 implementation is the record's question, not the consuming impl's.
+
+### 4.3 Implementation is OLDER than record (e.g. impl is v1.0, record is v1.2)
+
+**Required behavior:** accept and process the fields the impl understands, ignore the rest. SPEC.md §2.6 (forward-compatible by extension) requires that unknown fields not cause parse failure.
+
+Implementation details:
+- New optional fields: ignored silently. No warning required.
+- New event-type values: treat as opaque strings. Don't reject just because the value isn't in the impl's known list.
+- New extension fields: ignored (namespaced or not).
+
+If the record has `schema_version` newer than the impl knows about: the impl SHOULD include a warning in logs or output indicating "schema_version X is newer than the impl supports; processing what is understood." The impl MUST NOT refuse to process.
+
+### 4.4 Implementation is across a MAJOR version (e.g. impl is v1.x, record is v2.0)
+
+**Default behavior:** reject. A v1.x impl is not required to consume v2.0 passports; they may have semantics it doesn't understand.
+
+**Recommended behavior:** include a compatibility module that wraps v2.0 records into a v1.x-compatible shape where possible. This is what `cryptography`, `protobuf`, and most long-lived libraries do. The wrapping must be loss-tolerant (it's understood that some v2.0 fields cannot be represented in v1.x).
+
+### 4.5 Implementation is across a MAJOR version, other direction (e.g. impl is v2.0, record is v1.x)
+
+**Recommended behavior:** accept via a one-way migration shim. The v2.0 impl knows what v1.x looked like and can translate the record's structure to the v2.0 shape for internal processing.
+
+Reference implementations (`contextpassport/python`, `contextpassport/typescript`) will ship migration shims when v2.0 lands, in modules named `context_passport.compat.v1` and similar.
+
+---
+
+## 5. Migration playbook for operators
+
+When a new major version of the spec ships, an operator running a Context Passport pipeline has four migration patterns available. Choice depends on volume, risk tolerance, and downstream consumer flexibility.
+
+### 5.1 Cutover (simplest)
+
+At time T:
+- Stop accepting v1.x writes.
+- Update the impl to v2.0.
+- Begin accepting v2.0 writes.
+
+Existing v1.x records remain in storage, queried via a v1.x-aware reader.
+
+**Pros:** simple, well-understood.
+**Cons:** brief downtime; no in-flight compatibility.
+
+Suitable for operators with a maintenance window and small/zero co-existence requirement.
+
+### 5.2 Dual-write
+
+For a transition period (typically weeks):
+- The pipeline writes every commit twice — once as v1.x, once as v2.0.
+- Readers can use either version.
+- After the transition, drop the v1.x writes.
+
+**Pros:** zero downtime, downstream consumers migrate at their own pace.
+**Cons:** doubled storage cost during transition, doubled processing cost.
+
+Suitable for operators with mixed downstream consumers and the budget for the transition.
+
+### 5.3 Dual-publish via transformation
+
+The pipeline writes only v2.0. A separate process transforms v2.0 records back to v1.x shape on demand for v1.x consumers.
+
+**Pros:** single source of truth.
+**Cons:** the transformation must be precise; lossy transformations produce inconsistencies.
+
+Suitable for operators with a small number of v1.x consumers and the engineering capacity to maintain the transformer.
+
+### 5.4 Hard cutover with v1.x archive
+
+The pipeline switches to v2.0 at time T. All v1.x records are exported to a long-term archive (S3, glacier, IPFS) and removed from the live database. Verification of pre-T records becomes an explicitly slower operation that fetches from the archive.
+
+**Pros:** clean live state.
+**Cons:** v1.x records are no longer first-class — slow to query, separate access path.
+
+Suitable for operators where pre-T records are rarely queried (e.g., compliance archives for past audit periods).
+
+### Recommendation
+
+For most operators: **dual-write for 3-6 months, then cutover**. Costs you double storage for a quarter; gives every consumer a window to migrate; eliminates compatibility code from the long-term codebase.
+
+---
+
+## 6. Hash chain considerations across versions
+
+The hash chain depends on:
+- The canonical-JSON algorithm
+- The hash function (SHA-256)
+- The integrity-hash construction rule (`sha256(payload_hash + parent_hash)`)
+
+If any of these change in a major version, **the chain breaks at the version boundary**. A v2.0 record cannot have its `parent_hash` linked to a v1.x parent's `integrity_hash` if the underlying construction differs.
+
+Two ways to handle this:
+
+### 6.1 Chain reset
+
+Treat the version boundary as a chain root. The first v2.0 commit has `parent_id` set to the last v1.x commit (for human-readable continuity) but `parent_hash` set to null and `integrity_hash` computed from the new construction.
+
+The downstream verifier walking the chain detects the version transition (different `schema_version`) and uses the corresponding rules for each segment.
+
+### 6.2 Anchor-based bridging
+
+The last v1.x checkpoint and the first v2.0 checkpoint are both externally anchored (Bitcoin OTS). The chain continuity is provided not by the integrity_hash linkage but by the external anchors — anyone verifying records across the boundary uses the external anchors as the bridge.
+
+For operators running a Witness Log, anchor-based bridging is essentially free — checkpoints are already anchored. The only operational change is documenting that v1.x records' `integrity_hash` values cannot be directly recomputed under v2.0 rules.
+
+### Recommendation
+
+Use **chain reset** for v1.x → v2.0. It's the cleanest and matches what every other versioned chain (Git, blockchains, append-only logs) does at major-version boundaries.
+
+---
+
+## 7. Conformance across versions
+
+The conformance test suite at `contextpassport/conformance-tests` is versioned alongside the spec:
+
+- `vectors/v1.0/required/` — v1.0 Core conformance vectors
+- `vectors/v1.0/signed/` — v1.0 Signed conformance vectors
+- `vectors/v1.1/required/` — v1.1-specific vectors (when v1.1 ships)
+- `vectors/v2.0/required/` — v2.0 Core conformance vectors
+
+An implementation declares conformance at a specific version, not generically:
+
+```
+✓ Context Passport v1.0 Core Conformant
+✓ Context Passport v1.0 Signed Conformant
+✓ Context Passport v1.1 Core Conformant (additional)
+```
+
+A v1.1-conformant impl is implicitly v1.0-conformant (per the backward-compatibility contract). A v2.0-conformant impl is **not** implicitly v1.x-conformant; if it claims both, it must pass both test suites.
+
+Currently the vectors live in `vectors/required/` and `vectors/signed/` without version subdirectories. When v1.1 ships, the existing directories will be moved to `vectors/v1.0/` and new directories created. The runner will accept a `--spec-version` flag.
+
+---
+
+## 8. Extension promotion lifecycle
+
+A namespaced extension (e.g. `acme.payment_amount`) lives in `EXTENSIONS.md`. Over time, an extension may be promoted to a core field. The lifecycle:
+
+```
+Draft (in EXTENSIONS.md)
+   ↓ (6 months minimum + 3 independent implementations)
+Candidate (still in EXTENSIONS.md, marked "promotion candidate")
+   ↓ (RFC + community review)
+Promoted (added to SPEC.md in next minor version, alias retained)
+   ↓ (one full major version of overlap)
+Core only (namespaced alias removed in the next major version)
+```
+
+Implementations consuming a passport during the overlap window must accept either the namespaced form or the core form. After the core-only transition, namespaced uses of the same field name are treated as separate (un-promoted) extensions; the same string in the namespace prefix has no special meaning.
+
+This pattern ensures extensions can move toward being canonical without breaking implementations that adopted them early.
+
+---
+
+## 9. Deprecation policy
+
+Fields and behaviors that are being removed in a future major version are marked **deprecated** in the current version:
+
+- In SPEC.md: the field section has a "**Deprecated in v1.x; will be removed in v2.0**" note.
+- In code: the reference implementations emit a runtime warning when the deprecated field is used.
+- In the conformance test suite: a vector is added to verify the deprecation warning fires (where applicable).
+
+Deprecation requires at least one full minor version of advance notice (e.g., deprecated in v1.1, removed in v2.0 not earlier). For high-impact deprecations (e.g., removing a required field), longer advance notice is expected per the RFC process.
+
+---
+
+## 10. Communication channels for version events
+
+When a new minor or major version ships, the maintainers commit to publishing:
+
+- **Release notes** in the spec repo's `CHANGELOG.md`
+- **Migration guide** in `docs/migrations/v<old>-to-v<new>.md`
+- **GitHub release** tagging the spec at the new version
+- **A blog post or community announcement** at `contextpassport.com/blog/`
+- **A heads-up to known implementers** at least 30 days before the release date
+
+Implementers and operators who want to be notified early can:
+- Subscribe to releases on the spec repo
+- Watch the spec repo for new PRs labeled `version-bump`
+- Join the maintainer Discord/Slack (TBD)
+
+---
+
+## 11. Concrete example — what a v1.0 to v1.1 transition might look like
+
+A hypothetical v1.1 adds:
+- New optional field `created_by.organization_id` (a stable org-level identifier)
+- New event-type value `delegate` (for hand-off events with explicit delegation semantics)
+- Promoted extension: `darkmatter.witness_log_ref` → core field `witness_log_ref`
+
+Existing v1.0 implementations:
+- Consume v1.1 passports correctly: missing `organization_id` is fine (optional); unknown event-type `delegate` is treated as an opaque string; the namespaced `darkmatter.witness_log_ref` is ignored (as it was in v1.0); the core `witness_log_ref` is ignored (unknown field).
+- Do not need to upgrade.
+
+Existing v1.0 records:
+- Consumed by v1.1 implementations without modification.
+- Validate against the v1.1 schema (no new required fields, all v1.0 records are valid v1.1 records).
+
+Operators producing new records:
+- Upgrade SDK to v1.1.
+- Optionally start emitting `organization_id` and `witness_log_ref` core fields.
+- Optionally retire the namespaced `darkmatter.witness_log_ref` alias.
+
+This is the smoothest possible transition. Most minor versions should look like this.
+
+---
+
+## 12. Concrete example — what a v1.x to v2.0 transition might look like
+
+A hypothetical v2.0 adds:
+- Required field `created_by.organization_id` (was optional in v1.1)
+- Replaced canonical-JSON with JCS (RFC 8785) instead of the current sorted-keys serialization
+- Required `signature` block on all production passports
+
+Existing v1.x implementations:
+- Cannot consume v2.0 passports natively without modification.
+- The reference implementation ships `context_passport.compat.v1` that translates v2.0 records into a v1.x-compatible shape (lossy: the signature requirement cannot be downgraded).
+
+Existing v1.x records:
+- Consumed by v2.0 implementations via the v2.0 impl's `compat.v1` module.
+- Hash chains break at the version boundary (different canonical-JSON). Verifiers use the per-segment rule (v1.x rules for v1.x records, v2.0 rules for v2.0 records) and rely on external anchors (Witness Log) for cross-boundary continuity.
+
+Operators:
+- Receive 6+ months of advance notice in v1.x release notes.
+- Choose a migration pattern from §5.
+- Update SDKs and the receiving server simultaneously (or in compatible order — v2.0 server can accept v1.x writes via shim; v1.x server cannot accept v2.0 writes).
+- Document the boundary in their own audit logs so downstream consumers can locate the transition.
+
+Transitions like this should happen rarely (at most every few years).
+
+---
+
+## 13. What this document does not cover
+
+- **Specific upgrade tools.** Per-implementation. The reference implementations will ship them when needed.
+- **Backporting fixes from newer versions to older versions.** Generally not done. Operators on old versions are encouraged to upgrade.
+- **Versioning of the conformance test suite separately from the spec.** The two are versioned together by convention.
+
+---
+
+*Context Passport — design notes for implementers. Released under CC0 along with the rest of the specification.*

--- a/docs/witness-log.md
+++ b/docs/witness-log.md
@@ -1,0 +1,354 @@
+# Witness Log
+
+**Status:** Non-normative design note
+**Audience:** Operators building Context Passport receiving servers (e.g. DarkMatter, self-hosted implementations)
+**Companion to:** [docs/throughput-and-trust.md](throughput-and-trust.md), [docs/external-anchoring.md](external-anchoring.md)
+
+---
+
+## Why this document exists
+
+The Context Passport spec defines what a record looks like and how integrity is computed at the client. It does not define how a receiving server stores those records, makes them publicly verifiable, or provides inclusion proofs to a third party. That's the operator's problem.
+
+This document describes the Witness Log pattern — an operator-side architecture for turning incoming Context Passports into a public, append-only, externally-anchored record that a regulator, auditor, or counterparty can verify without trusting the operator.
+
+The pattern borrows from [Certificate Transparency](https://certificate.transparency.dev/), [Sigstore Rekor](https://docs.sigstore.dev/logging/overview/), and [Trillian](https://github.com/google/trillian). It is not novel. What's novel is applying it to AI agent execution records.
+
+---
+
+## 1. The three-tier model
+
+A Witness Log has three tiers, each producing a different kind of evidence:
+
+```
+Tier 1: Local commits          (client → operator, real-time)
+   ↓
+Tier 2: Checkpoint batches     (operator → checkpoint repo, periodic)
+   ↓
+Tier 3: External anchors       (checkpoint repo → Bitcoin / Sigstore / TSA)
+```
+
+| Tier | What it proves | Latency | Who can verify |
+|---|---|---|---|
+| 1. Local commit | Record was received by the operator at time T | Real-time | Operator only (server logs) |
+| 2. Checkpoint | Record was included in the public log at the checkpoint time | Seconds to minutes | Anyone with access to the checkpoint repo |
+| 3. External anchor | The checkpoint itself existed at an external time | Hours (Bitcoin confirmation) | Anyone with access to the external chain |
+
+A passport progresses through these tiers in order. Different verifiers care about different tiers depending on their trust posture. A regulator who trusts the operator may verify only at tier 1. A regulator who trusts no one waits for tier 3.
+
+---
+
+## 2. Tier 1 — Local commit reception
+
+The receiving server accepts passports from clients (per `docs/throughput-and-trust.md` submission patterns), validates them, and stores them. Required validation at this tier:
+
+- **Schema validation:** the incoming passport validates against `schema/v1.json`.
+- **Hash validation:** `integrity.payload_hash` recomputed by the server matches the client-supplied value. If not, the passport is stored but flagged with `verification_status: rejected` and the reason recorded.
+- **Chain validation:** if `parent_id` is set, the parent passport is fetched and `integrity.parent_hash` is verified to match its `integrity_hash`. Broken chains are flagged but stored.
+- **Signature validation (if present):** the Ed25519 (or other algorithm) signature is verified against the embedded public key. Failures are flagged but stored.
+
+Storage requirements:
+
+- **Append-only.** The database table or storage layer MUST NOT permit `UPDATE` or `DELETE` on committed records. Use database-level constraints (Postgres triggers, table-level GRANT) to enforce this rather than relying on application code.
+- **Indexed for chain traversal.** Lookups by `id`, `parent_id`, `trace_id` should be O(log n) at minimum.
+- **Durable before ack.** The server MUST persist the passport before returning a receipt to the client. A receipt for a record not actually durable is a credibility hole.
+
+Reference: DarkMatter uses a Postgres `commits` table with `INSERT`-only RLS policies and a constraint trigger preventing column modification. The implementation is in `src/server.js`.
+
+---
+
+## 3. Tier 2 — Checkpoint construction
+
+Every N seconds (or every M commits, whichever comes first), the server:
+
+1. Selects all commits since the last checkpoint.
+2. Computes a Merkle tree over their `integrity_hash` values.
+3. Constructs a checkpoint envelope:
+
+```json
+{
+  "schema_version":   "3",
+  "checkpoint_id":    "ckpt_2026-05-18T14:30:00Z_abc123",
+  "previous_id":      "ckpt_2026-05-18T14:20:00Z_xyz789",
+  "merkle_root":      "sha256:...",
+  "leaf_count":       1247,
+  "first_leaf_id":    "ctx_...",
+  "last_leaf_id":     "ctx_...",
+  "first_leaf_time":  "2026-05-18T14:20:00.013Z",
+  "last_leaf_time":   "2026-05-18T14:29:59.872Z",
+  "checkpoint_time":  "2026-05-18T14:30:00.000Z"
+}
+```
+
+4. Signs the checkpoint with the operator's signing key.
+5. Publishes the signed checkpoint to a **public, append-only repository**. The reference implementation uses a public GitHub repo with one commit per checkpoint. Each checkpoint commit is signed with the operator's GPG key.
+
+A few design choices worth being explicit about:
+
+### Why a Merkle tree?
+
+A Merkle tree over the batch lets a client request a compact proof that *their* commit is in *this* checkpoint without downloading the entire checkpoint contents. The proof is logarithmic in the size of the batch.
+
+### Why a separate `schema_version`?
+
+The checkpoint envelope is a different schema from the Context Passport itself. Mixing them creates ambiguity. The DarkMatter implementation uses `"3"` for checkpoint envelopes specifically to avoid collision with Context Passport `"1.0"` and DarkMatter's internal commit envelope `"2"`.
+
+### Why a public GitHub repo?
+
+- Git itself is content-addressed and append-only by convention.
+- GitHub provides free, durable hosting with global mirroring.
+- Anyone can clone, fork, or audit the repo.
+- GPG-signed commits add operator attestation without separate signing infrastructure.
+- Tag-based releases let operators publish "checkpoint of checkpoints" for long-term archival.
+
+Alternatives that work equally well: a write-only S3 bucket with object versioning, an IPFS pinning service, a self-hosted Git server with anonymous read access. The pattern requires public read access and append-only writes; the storage technology is implementation-defined.
+
+### Checkpoint cadence
+
+- **Real-time-critical workflows:** every 1 minute. High operational overhead but lowest latency to tier-2 proof.
+- **Default:** every 10 minutes. Balances proof latency with checkpoint repo size growth.
+- **Low-volume operators:** every hour. Acceptable when commits are infrequent.
+
+The cadence is a per-operator policy. Clients SHOULD NOT assume any particular cadence and SHOULD request inclusion proofs explicitly rather than waiting for a specific elapsed time.
+
+---
+
+## 4. Tier 3 — External anchoring of checkpoints
+
+Each published checkpoint's `merkle_root` is submitted to one or more external timestamping services (see `docs/external-anchoring.md`). The resulting proof files are stored alongside the checkpoint.
+
+The key insight: **one external anchor per checkpoint, not per commit**. A single Bitcoin anchor (via OpenTimestamps) covers an entire batch of thousands of commits at no per-commit cost. The Merkle tree's logarithmic inclusion proofs do the rest.
+
+Anchoring strategy:
+
+```
+Per checkpoint:
+  1. ots stamp <merkle_root>          → ~/.ots-pending/<checkpoint_id>.ots
+  2. Wait 1-6 hours for confirmation
+  3. ots upgrade <checkpoint_id>.ots  → fully Bitcoin-anchored
+  4. Commit upgraded proof to checkpoint repo
+```
+
+Operators MAY anchor to multiple services in parallel for redundancy:
+
+- OpenTimestamps (Bitcoin)
+- Sigstore Rekor (transparency log)
+- An RFC 3161 TSA (compliance-mandated)
+- A second OpenTimestamps calendar (independent operator)
+
+Each anchor adds bytes (~1 KB per proof) to the checkpoint repo and one optional verification path for downstream consumers. Four anchors at near-zero marginal cost converts a single-witness pipeline into a four-witness one.
+
+---
+
+## 5. Inclusion proofs
+
+The point of the whole architecture is that a client (or third party holding a passport) can ask: "is this passport included in your Witness Log?" and receive a verifiable answer that doesn't require trusting the server.
+
+The inclusion-proof flow:
+
+```
+Client:  "Prove ctx_1700000000000_abc is in the log."
+Server:  Returns {
+           checkpoint_id:      "ckpt_2026-05-18T14:30:00Z_abc123",
+           merkle_path:        [<hash>, <hash>, <hash>, ...],   // log(N) sibling hashes
+           leaf_index:         527,
+           checkpoint_url:     "https://github.com/.../checkpoints/.../ckpt_....json",
+           ots_proof_url:      "https://github.com/.../checkpoints/.../ckpt_....ots"
+         }
+
+Client (or any third party):
+  1. Fetch the checkpoint from checkpoint_url.
+  2. Verify the checkpoint is signed by the operator's known key.
+  3. Recompute the Merkle root from the passport's integrity_hash + the merkle_path.
+  4. Confirm the recomputed root matches checkpoint.merkle_root.
+  5. Optionally: download ots_proof_url and verify the merkle_root was Bitcoin-anchored.
+```
+
+If all steps pass, the client has cryptographic evidence that:
+
+- The passport with that `integrity_hash` was included in a checkpoint at a specific time.
+- The operator vouched for the checkpoint (signature).
+- The checkpoint existed at the externally-anchored time (independent of the operator).
+
+This is the same proof structure as Certificate Transparency's inclusion proofs and Sigstore Rekor's transparency log proofs. Verifier code from those projects can often be adapted with small changes.
+
+---
+
+## 6. Operator architecture (reference)
+
+The pattern from DarkMatter's implementation, as a reference:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                       Receiving server                           │
+│  ┌──────────────┐    ┌───────────────┐    ┌──────────────────┐   │
+│  │ POST /commit │───▶│ Validation    │───▶│ Postgres commits │   │
+│  │              │    │ (hash, chain, │    │ (append-only)    │   │
+│  │              │    │  signature)   │    │                  │   │
+│  └──────────────┘    └───────────────┘    └──────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+                                              │
+                       Every 10 minutes ──────┤
+                                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                  Checkpoint scheduler                            │
+│  ┌────────────────────┐    ┌────────────────────────────────┐    │
+│  │ Read new commits   │───▶│ Build Merkle tree              │    │
+│  │ since last ckpt    │    │ Sign checkpoint envelope (GPG) │    │
+│  └────────────────────┘    └────────────────────────────────┘    │
+│                                              │                   │
+│                                              ▼                   │
+│                            ┌─────────────────────────────────┐   │
+│                            │ git commit + push to            │   │
+│                            │ github.com/<org>/witness-log    │   │
+│                            └─────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+                                              │
+                       Every checkpoint ──────┤
+                                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│              External anchoring (async, can lag)                 │
+│  ┌──────────────────┐    ┌───────────────────────────────┐       │
+│  │ ots stamp        │───▶│ Wait for Bitcoin confirmation │       │
+│  │ merkle_root      │    │ Upgrade .ots proof            │       │
+│  └──────────────────┘    └───────────────────────────────┘       │
+│                                              │                   │
+│                                              ▼                   │
+│                            ┌─────────────────────────────────┐   │
+│                            │ git commit upgraded .ots files  │   │
+│                            └─────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────┘
+                                              │
+                                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                  GET /api/inclusion-proof/:id                    │
+│  Returns merkle_path + checkpoint reference + .ots URL.          │
+│  Verifier needs no trust in the server.                          │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three independent processes:
+
+1. **Receiving server** — the always-on API. Synchronous request/response. Low complexity. Failures here are user-visible.
+2. **Checkpoint scheduler** — a periodic process. Can be a cron job, a separate worker, a Cloud Run scheduled task. Failures here delay checkpoint publication but do not affect commit ingestion.
+3. **External anchoring worker** — fully asynchronous. Submits checkpoints to OTS, waits, upgrades proofs, publishes. Failures here delay external anchoring but do not affect anything else.
+
+Each can be scaled, deployed, and operated independently. This is the standard separation-of-concerns pattern; the architecture is not novel.
+
+---
+
+## 7. Public verifier — what a third party runs
+
+The operator publishes (in the witness-log repo or in docs):
+
+- The schema for the checkpoint envelope
+- The Merkle tree construction algorithm (left-right ordering, hash function, leaf encoding)
+- The operator's signing public key
+- A reference verifier in code
+
+A complete verifier needs roughly 150 lines of code. The DarkMatter reference verifier is published at `github.com/darkmatter-hub/darkmatter` (a Python script that takes a passport `id` and returns "verified" / "broken" / "not yet anchored" with the proof chain).
+
+Anyone can run the verifier offline given:
+
+- The passport JSON
+- The merkle_path from the inclusion-proof endpoint (or downloaded directly from the checkpoint repo)
+- The checkpoint envelope and the operator's signing key
+- (Optional) The OTS proof for the checkpoint's Merkle root
+
+Network access is needed only to fetch the checkpoint repo contents (one HTTP GET) and to verify the Bitcoin block if the OTS proof is being checked.
+
+---
+
+## 8. Operational considerations
+
+### Repo size growth
+
+A checkpoint envelope is ~1-2 KB. A 10-minute cadence produces ~52,560 checkpoints per year, or ~100 MB of checkpoint envelopes. With .ots proofs (~1 KB each), about 200 MB/year. Manageable indefinitely in a single GitHub repo.
+
+For very large operators (>1M commits/day), consider:
+
+- Annual repo rollover (`witness-log-2026/`, `witness-log-2027/`)
+- Sparse fetch for verifiers (Git supports fetching only specific directories)
+- Mirror to IPFS or S3 for redundancy
+
+### Operator key compromise
+
+If the operator's GPG key (used to sign checkpoints) is compromised:
+
+1. An attacker can sign forged checkpoints. The fraud is detectable because:
+   - Existing checkpoints are immutable (already in git history).
+   - External anchors (Bitcoin OTS) for past checkpoints cannot be forged retroactively.
+   - The fraud surfaces as a forked checkpoint chain — a verifier seeing two checkpoints with the same `previous_id` knows something is wrong.
+
+2. Operator response: publish a key rotation announcement, revoke the old GPG key, sign all subsequent checkpoints with the new key. Past records remain verifiable via the old key combined with their external anchors.
+
+This is the same threat model and response pattern as Certificate Transparency log operator key compromise. Well-understood.
+
+### What happens if the operator disappears
+
+Every committed passport remains verifiable as long as:
+
+- The passport JSON is held by the customer
+- The checkpoint envelope is in the public repo (GitHub keeps repos indefinitely, but customers should also mirror the repo)
+- The OTS proof file is in the public repo
+
+The customer can verify offline using the same reference verifier code without needing the operator's server to be alive. This is the "even if the operator goes away" property advertised on the DarkMatter homepage.
+
+### Latency budget for inclusion proofs
+
+| Tier | Typical latency | Failure mode |
+|---|---|---|
+| Tier 1 (commit ack) | 10-100ms | Returns 503; client retries |
+| Tier 2 (checkpoint published) | < cadence (10 min default) | Scheduler delayed; commits backlog briefly |
+| Tier 3 (external anchor confirmed) | 1-6 hours (Bitcoin) | Anchor delayed; tier-2 proof remains usable |
+
+Clients SHOULD treat tier-2 proofs as the primary evidence and tier-3 anchors as the long-term guarantee. The tier-3 anchor is what makes the proof regulator-grade; the tier-2 proof is what makes it real-time-useful.
+
+---
+
+## 9. Public-good vs. competitive infrastructure
+
+The Witness Log is a public good. Once an operator publishes a checkpoint repo with anchored checkpoints, **anyone** can:
+
+- Verify any passport that was committed to that operator's pipeline
+- Audit the operator's claims about uptime, throughput, and chain integrity
+- Build downstream tools that consume the checkpoint feed
+
+This is intentional. A receiving server that doesn't publish a Witness Log is just a fancy database; what makes Context Passport credible is that the operator commits publicly and irrevocably to what they received.
+
+Multiple operators can run independent Witness Logs. A customer using two operators can cross-reference: if both operators witnessed the same chain, the trust assumptions can be combined or relaxed. Operators that participate in cross-witnessing strengthen each other's credibility without coordination overhead.
+
+---
+
+## 10. Minimum viable Witness Log
+
+For a new operator wanting to ship the smallest viable Witness Log:
+
+1. Create a public GitHub repo: `github.com/<your-org>/witness-log`.
+2. Commit a `README.md` explaining the operator's verification expectations and where to find verifier code.
+3. Add a `checkpoints/` directory.
+4. Stand up a scheduler that every N minutes:
+   - Builds a Merkle tree over the new commits
+   - Writes `checkpoints/<timestamp>.json` (the checkpoint envelope)
+   - Writes `checkpoints/<timestamp>.sig` (the operator's signature)
+   - `git commit && git push`
+5. Add an async worker that:
+   - Runs `ots stamp` on each new checkpoint's `merkle_root`
+   - Periodically runs `ots upgrade` on pending proofs
+   - Commits the upgraded `.ots` files
+6. Add an HTTP endpoint that returns inclusion proofs from a passport `id`.
+7. Publish (in the repo README) the verifier code that consumers should run.
+
+That's the entire architecture. Total code: a few hundred lines per component. Total operational cost: a small Postgres database, a small worker, a public GitHub repo. The rest is policy and operational discipline.
+
+---
+
+## 11. What this document does not cover
+
+- **The specific schema for the checkpoint envelope.** This is operator-defined. The DarkMatter implementation uses one specific schema; other operators MAY use different schemas as long as they document them.
+- **Cross-operator interoperability.** Two operators with different checkpoint schemas cannot directly cross-verify each other's logs. Standardization here is a future spec work item.
+- **Privacy-preserving Witness Logs.** Some operators may need to publish anchors without exposing which commits are in them (e.g., for confidential workflows). This requires a different cryptographic construction (e.g., a polynomial commitment or KZG-based proof) and is out of scope for v1.0.
+
+---
+
+*Context Passport — design notes for implementers. Released under CC0 along with the rest of the specification.*


### PR DESCRIPTION
Three new non-normative design notes covering signing key patterns, operator-side Witness Log architecture, and versioning/migration playbook. All under docs/. README updated to surface them. Non-normative; does not change conformance criteria.