### PR TITLE
docs: regulatory-mapping + threat-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The goal: become the standard envelope format for AI agent events — a record a
   - [`key-management.md`](docs/key-management.md) — file-based, PKI/X.509, and DID-based signing key patterns
   - [`witness-log.md`](docs/witness-log.md) — operator architecture for publishing public, anchored checkpoint chains
   - [`migration-and-versioning.md`](docs/migration-and-versioning.md) — minor vs. major versions, cross-version compatibility, upgrade playbook
+  - [`regulatory-mapping.md`](docs/regulatory-mapping.md) — field-by-field mapping to EU AI Act, FINRA 17a-4, HIPAA, SOX, GDPR, PCI DSS, ISO/IEC 42001, NIST AI RMF
+  - [`threat-model.md`](docs/threat-model.md) — adversaries, defenses, defense-in-depth recommendations
 - [`proposals/`](proposals/) — draft proposals
   - [`context-passport-for-mcp.md`](proposals/context-passport-for-mcp.md) — MCP extension proposal
 - [`EXTENSIONS.md`](EXTENSIONS.md) — vendor-namespaced extension registry

--- a/docs/regulatory-mapping.md
+++ b/docs/regulatory-mapping.md
@@ -1,0 +1,342 @@
+# Regulatory Mapping
+
+**Status:** Non-normative reference
+**Audience:** Compliance officers, legal counsel, audit teams, sales engineers explaining Context Passport to regulated buyers
+**Disclaimer:** This document describes how Context Passport's technical properties align with specific regulatory requirements. It is not legal advice. Compliance is determined by your legal counsel and any applicable notified body or auditor, not by this document.
+
+---
+
+## Why this document exists
+
+Compliance teams evaluating Context Passport need to know which of their existing regulatory obligations the standard helps satisfy and which it does not. Engineers building Context Passport-based pipelines need to know which fields are load-bearing for compliance use cases. This document is the field-by-field bridge between regulatory text and the spec.
+
+Each section follows the same structure:
+
+1. **What the regulation requires** — direct quote or close paraphrase of the operative text
+2. **How Context Passport satisfies it** — which fields and properties map to the requirement
+3. **What is still on the operator** — gaps the spec does not fill, which the operator must address through other means
+
+---
+
+## 1. EU AI Act — Article 12 (Logging) and Article 26 (Provider obligations)
+
+### What the regulation requires
+
+Article 12 of [Regulation (EU) 2024/1689](https://eur-lex.europa.eu/eli/reg/2024/1689/oj) (the EU AI Act) requires providers of high-risk AI systems to ensure their systems **"technically allow for the automatic recording of events ('logs') over the lifetime of the system."** The recording must be sufficient to:
+
+- (a) Identify situations that may result in the AI system presenting a risk under Article 79(1), or in a substantial modification of the system
+- (b) Facilitate post-market monitoring as referenced in Article 72
+- (c) Monitor the operation of high-risk AI systems referred to in Article 26(5)
+
+The Commission's interpretive guidance treats **"traceability"** as a structural property of the record itself, not merely a claim by the provider that records exist.
+
+### How Context Passport satisfies it
+
+| Article 12 requirement | Context Passport mechanism |
+|---|---|
+| Automatic recording of events | `dm.commit()` (or equivalent SDK call) at decision time produces one passport per agent action. Every action that may bear on risk identification, post-market monitoring, or operational monitoring is captured. |
+| Records sufficient to identify risk situations | `payload.input`, `payload.output`, `created_by.agent_id`, `created_by.model`, `event.type`, `event.timestamp` together provide the inputs, outputs, identity, and timing necessary for risk-situation reconstruction. |
+| Records sufficient to facilitate post-market monitoring | `parent_id` chaining permits replay of the full decision history of a single trace. `trace_id` groups related decisions into a single monitored pipeline. |
+| Records sufficient to monitor operation | The hash chain (`integrity_hash`, `parent_hash`) makes any tampering with historical records detectable by the operator or by any auditor. |
+| Traceability as a structural property | `integrity_hash` + optional Ed25519 signature (SPEC.md §3.2.7) + external anchoring (docs/external-anchoring.md) make the record verifiable by a third party with no trust in the operator. This is the structural difference between a self-reported log and a traceable record. |
+
+### What is still on the operator
+
+- **Retention period.** Article 12 implies logs must be kept "over the lifetime of the system." Context Passport does not specify retention; the operator must implement durable storage with appropriate retention policies.
+- **Risk-situation identification.** Determining which events constitute a "risk situation under Article 79(1)" is the provider's substantive judgment, not a property of the record format.
+- **System-level documentation.** Article 11 (technical documentation) requires extensive system documentation that Context Passport does not address.
+- **Notified-body interaction.** The notified body's interpretation of "sufficient" for a specific deployment is determined case-by-case.
+
+---
+
+## 2. EU AI Act — Article 79 (Procedure for AI systems presenting a risk)
+
+### What the regulation requires
+
+Article 79 establishes the procedure for handling AI systems that present a risk to health, safety, or fundamental rights. When competent authorities investigate, the provider must furnish "all the information and documentation necessary to demonstrate the conformity" of the system.
+
+### How Context Passport satisfies it
+
+| Requirement | Context Passport mechanism |
+|---|---|
+| Demonstrate conformity post-incident | The hash chain of historical records, combined with external anchoring of checkpoints, lets the provider produce evidence that survives independent verification by the competent authority. |
+| Demonstrate records were not modified after the incident was discovered | External anchoring (Bitcoin via OpenTimestamps) proves the records' hashes existed at the externally-attested time. Modifying records after the incident is detectable because the new hashes would not match the anchored ones. |
+| Reconstruct the decision lineage of the relevant action | `parent_id` and `trace_id` permit walking the full chain backward from the incident to first cause. |
+
+### What is still on the operator
+
+- **Article 79 reporting timelines.** The operator must produce evidence within the procedural timelines. Slow Witness Log retrieval is the operator's problem, not the spec's.
+- **Identifying which records are relevant.** Context Passport supports searching, but the operator must build the search index and the case-specific filters.
+
+---
+
+## 3. FINRA 17a-4 (Books and records requirements for broker-dealers)
+
+### What the regulation requires
+
+[SEC Rule 17a-4](https://www.sec.gov/rules-regulations/2022/10/electronic-recordkeeping-requirements-broker-dealers-security-based-swap-dealers-major) (as amended in 2022) requires broker-dealers to preserve records in either a **write-once, read-many (WORM)** format or an **audit-trail-based** format. The audit-trail option requires the system to:
+
+- Maintain a complete, time-stamped audit trail of all modifications, including original records, modified records, the identity of the modifier, the date and time of each modification
+- Verify the integrity, accuracy, and reliability of the recordkeeping system
+- Permit re-creation of the original record without alteration
+
+### How Context Passport satisfies it
+
+| 17a-4 requirement | Context Passport mechanism |
+|---|---|
+| WORM-equivalent integrity | The append-only constraint in operator storage (docs/witness-log.md §2) plus the hash chain prevents modification. Records cannot be silently altered. |
+| Audit trail of modifications | Context Passport does not modify records — every change is a new commit chained to the previous. The chain is itself the audit trail. |
+| Identity of modifier | `created_by.agent_id`, optionally with Ed25519 signature, provides authoritative attribution. |
+| Time-stamped modifications | `event.timestamp` (client-side) plus server-receipt timestamp plus optional external anchor provide three independently-verifiable time properties. |
+| Verify integrity, accuracy, reliability | The hash chain + signature provide cryptographic verification. The reference verifier (open source) lets any party check independently. |
+| Re-create the original record | Records are immutable. The original is always available; there is no "modified" version to distinguish from. |
+
+### What is still on the operator
+
+- **Designated Third-Party Downloader (D3P).** 17a-4 requires the firm to designate an independent third party able to download records to satisfy SEC requests. The operator must designate and contract with such a party; Context Passport provides the data format but not the personnel arrangement.
+- **Retention period.** SEC mandates 3-6 years depending on record type. Retention is operator policy.
+- **Pre-production attestation.** The firm must file a notice with the SEC before adopting the audit-trail-based option. The notice is the firm's responsibility.
+
+---
+
+## 4. HIPAA — 45 CFR §164.312(b) (Audit controls)
+
+### What the regulation requires
+
+The HIPAA Security Rule's [Audit Controls standard](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-C/part-164/subpart-C/section-164.312#p-164.312(b)) requires covered entities to "implement hardware, software, and/or procedural mechanisms that record and examine activity in information systems that contain or use electronic protected health information."
+
+§164.308(a)(1)(ii)(D) further requires regular review of records of information-system activity to identify potential security violations.
+
+### How Context Passport satisfies it
+
+| HIPAA requirement | Context Passport mechanism |
+|---|---|
+| Record activity in systems handling PHI | `payload` records the activity; `event.type` distinguishes commit / access / share / consent events. |
+| Examine activity | The hash chain plus the verifier permit independent examination. The structured payload allows automated analysis. |
+| Identify potential security violations | Continuity expectations (see docs/throughput-and-trust.md §5.3) + chain breaks + signature failures all surface as machine-detectable signals. |
+
+### What is still on the operator
+
+- **Encryption of PHI.** The Security Rule's encryption requirements are separate. Context Passport's payload is not encrypted by default; operators handling PHI MUST encrypt the payload before committing (BYOK pattern; see SPEC.md §5.2).
+- **Access controls.** §164.312(a) requires unique user identification and access controls. Context Passport provides the audit trail; access controls live at the application layer.
+- **Breach notification.** A breach involving Context Passport records still triggers breach-notification rules. The fact that the records are tamper-evident may inform the harm assessment but does not eliminate the obligation.
+
+---
+
+## 5. SOX § 404 (Internal control over financial reporting)
+
+### What the regulation requires
+
+Section 404 of the [Sarbanes-Oxley Act of 2002](https://www.govinfo.gov/content/pkg/PLAW-107publ204/pdf/PLAW-107publ204.pdf) requires public companies to:
+
+- Establish and maintain internal control over financial reporting (ICFR)
+- Annual management assessment of ICFR effectiveness
+- External auditor attestation on ICFR (for accelerated filers)
+
+PCAOB Auditing Standard 2201 elaborates the auditor's requirements, including evaluation of the integrity of financial-reporting data.
+
+### How Context Passport satisfies it
+
+When AI agents are involved in financial-reporting workflows (transaction approval, journal-entry generation, reconciliation), Context Passport provides:
+
+| SOX/ICFR concern | Context Passport mechanism |
+|---|---|
+| Authorization controls | `created_by.agent_id` + signature establish who authorized each agent action. |
+| Segregation of duties | Records of multi-agent workflows show which agent did which step; combined with role-based controls upstream, this supports SoD enforcement. |
+| Audit trail for material transactions | Every commit is part of an immutable, signed chain. Auditors can recompute and verify the chain independently. |
+| Change detection | The hash chain makes any post-hoc modification of an agent's recorded decision detectable. |
+
+### What is still on the operator
+
+- **Risk assessment scoping.** Determining which agent actions are "material" to financial reporting and therefore in-scope for ICFR is the management's substantive judgment.
+- **Control documentation.** SOX requires documented control descriptions. Context Passport is a control component; the description of the broader control environment is the operator's.
+- **Independent testing.** SOX requires independent testing of controls. The auditor will test Context Passport-based controls; the operator must provide access and explanation.
+
+---
+
+## 6. GDPR — Article 30 (Records of processing activities)
+
+### What the regulation requires
+
+Article 30 of the [General Data Protection Regulation](https://gdpr.eu/article-30-records-of-processing-activities/) requires controllers and processors to maintain records of processing activities, including:
+
+- Categories of data subjects and personal data
+- Categories of recipients
+- Transfers to third countries
+- Time limits for erasure
+- Description of technical and organizational security measures
+
+Article 32 separately requires "the ability to ensure the ongoing confidentiality, integrity, availability and resilience of processing systems and services."
+
+### How Context Passport satisfies it
+
+| GDPR concern | Context Passport mechanism |
+|---|---|
+| Demonstrate processing activities | Each `commit` event captures one processing activity by an AI agent. The chain provides the longitudinal record. |
+| Demonstrate integrity (Art. 32) | The hash chain + signature + external anchoring jointly provide integrity guarantees. |
+| Support data-subject access requests (Art. 15) | `payload.input` and `payload.output` may contain personal data; `trace_id` groups activities affecting a single data subject. |
+| Support erasure requests (Art. 17) — see caveat | The append-only design conflicts with literal erasure. Operators must address this through pseudonymization or by separating personal data from the immutable record. |
+
+### What is still on the operator
+
+- **Right to erasure conflict.** The append-only chain cannot literally erase records. Two operator approaches:
+  - **Pseudonymization.** Store personal data with pseudonymous identifiers in the passport; maintain the mapping in a separate, deletable store. When a data subject requests erasure, delete the mapping. The passport remains but is no longer linkable to a person.
+  - **Off-chain personal data.** Store personal data outside the passport entirely; include only a content hash. Erasure deletes the off-chain data; the passport becomes a record-of-the-record that no longer exposes personal information.
+- **Lawful basis.** Article 6 requires a lawful basis for processing. Recording activity does not establish a lawful basis for the activity itself.
+- **Data Protection Impact Assessment (DPIA).** Article 35 may require a DPIA for high-risk AI processing. Context Passport supports the assessment but does not perform it.
+
+---
+
+## 7. PCI DSS — Requirement 10 (Track and monitor all access to network resources and cardholder data)
+
+### What the regulation requires
+
+[PCI DSS v4.0](https://www.pcisecuritystandards.org/document_library/) Requirement 10 mandates audit trails for all individual access to cardholder data, with specific data elements: user identification, type of event, date and time, success/failure indication, origination, identity of affected data/system. Audit trail files must be protected from modification.
+
+### How Context Passport satisfies it
+
+| PCI DSS 10 element | Context Passport mechanism |
+|---|---|
+| 10.2 — Implement automated audit trails for all system components | `dm.commit()` per access event. |
+| 10.3.1 — User identification | `created_by.agent_id`. |
+| 10.3.2 — Type of event | `event.type`. |
+| 10.3.3 — Date and time | `event.timestamp` + `created_at` + server-receipt time. |
+| 10.3.4 — Success or failure indication | `event.type` may be `commit` (success) or `error` (failure); `payload.output` distinguishes. |
+| 10.3.5 — Origination of event | `created_by` block. |
+| 10.3.6 — Identity or name of affected data, system component | `payload` content. |
+| 10.5 — Protect audit trail files from modification | Hash chain + append-only storage + external anchoring. |
+
+### What is still on the operator
+
+- **Cardholder data must not appear in passport payloads in plaintext.** Encrypt or tokenize PAN/CVV before committing; store the encrypted form in the payload.
+- **Daily log review.** Requirement 10.6 requires daily review of audit logs. Context Passport provides the data; the review process is operator policy.
+
+---
+
+## 8. ISO/IEC 42001 (Artificial Intelligence Management System)
+
+### What the regulation requires
+
+[ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html) is the first international management-system standard for AI. Annex A includes controls for AI system lifecycle management, including A.6.2.5 (AI system documentation), A.7.4 (data quality records), and A.9.2 (system operation monitoring).
+
+### How Context Passport satisfies it
+
+| 42001 control | Context Passport mechanism |
+|---|---|
+| A.6.2.5 — System documentation | The full chain of agent decisions is documentation of system behavior. |
+| A.7.4 — Data quality records | `payload.input` and `payload.output` together document the data each agent saw and produced. |
+| A.9.2 — System operation monitoring | The continuous append-only chain is the operational monitoring artifact. |
+| Continuous improvement | The chain enables retrospective analysis of agent decisions; patterns of poor outcomes can be identified and remediated. |
+
+### What is still on the operator
+
+- **Management commitment, policy, and roles.** 42001 requires a formal AI management system with documented commitment, policy, and assigned roles. Context Passport is a technical component; the management system around it is the operator's work.
+- **Risk and impact assessments.** 42001 requires AI risk and impact assessments. Records produced by Context Passport inform these but do not perform them.
+
+---
+
+## 9. NIST AI Risk Management Framework (AI RMF 1.0)
+
+### What the regulation requires
+
+[NIST AI RMF 1.0](https://www.nist.gov/itl/ai-risk-management-framework) is a voluntary framework with four functions: Govern, Map, Measure, Manage. Within Measure 2.7, AI systems should produce data sufficient for accountability tracing.
+
+### How Context Passport satisfies it
+
+| AI RMF function | Context Passport mechanism |
+|---|---|
+| Measure 2.7 — Accountability traceability | The chain provides traceability from outcome backward through the agent's decisions. |
+| Manage 1.3 — Risk monitoring | The append-only record supports post-hoc analysis when risks materialize. |
+| Govern 1.4 — Documentation | The chain is itself documentation of AI system behavior. |
+
+### What is still on the operator
+
+- **Map function.** Identifying the AI system's risks requires substantive analysis; Context Passport supports it but does not perform it.
+- **Stakeholder engagement.** NIST emphasizes engaging affected communities; this is process, not data.
+
+---
+
+## 10. State-level proposals (US)
+
+Several US states have proposed AI auditing requirements. Notable examples:
+
+- **California SB 1047 (vetoed September 2024)** — would have required model developers to implement safety and security protocols, including incident reporting.
+- **New York City Local Law 144** — requires bias audits for automated employment decision tools, with publicly-available audit results.
+- **Colorado AI Act (SB24-205)** — effective February 2026, requires developers and deployers of high-risk AI systems to provide impact assessments.
+
+Context Passport's audit-trail properties support compliance with the recordkeeping aspects of these regimes. Each has specific procedural requirements that the spec does not address.
+
+---
+
+## 11. Sector-specific frameworks
+
+### Banking — Federal Reserve SR 11-7 (Model Risk Management)
+
+The Federal Reserve's [SR 11-7](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) guidance requires banks to validate models, document their development and use, and track ongoing performance. When AI agents make modeled decisions:
+
+- Context Passport's commit chain documents each model invocation, including model version (`created_by.model`).
+- Performance tracking can be built on top of the queryable record.
+
+### Aviation — FAA Part 121 (cockpit voice recorder / flight data recorder analogy)
+
+Aviation's "black box" requirements are an instructive analogy: independent recording of operational events, tamper-evident, retained for post-incident analysis. Context Passport provides equivalent properties for AI agent operations. No formal FAA regulation maps to AI agents yet, but the conceptual mapping is direct.
+
+### Healthcare — FDA Software as a Medical Device (SaMD) audit trail expectations
+
+The FDA's [SaMD framework](https://www.fda.gov/medical-devices/digital-health-center-excellence/software-medical-device-samd) expects manufacturers to maintain documentation of software behavior in the field. For AI-based SaMD, this includes the decisions the AI made and the inputs it considered. Context Passport supports both.
+
+---
+
+## 12. Mapping summary table
+
+| Framework | Primary Context Passport mechanism | Operator additional work |
+|---|---|---|
+| EU AI Act Art. 12 | Automatic commits + hash chain + external anchoring | Risk-situation identification, retention policy |
+| EU AI Act Art. 79 | Externally-anchored chain provides post-incident evidence | Reporting timelines, evidence retrieval infrastructure |
+| FINRA 17a-4 | Append-only storage + hash chain satisfies audit-trail option | D3P designation, SEC notice filing |
+| HIPAA §164.312(b) | Activity recording + verification | Encryption of PHI in payload, access controls |
+| SOX § 404 | Authorization records + audit trail | Materiality determination, control documentation |
+| GDPR Art. 30 | Processing activity records + integrity | Erasure handling (pseudonymization or off-chain personal data) |
+| PCI DSS 10 | Audit trail elements + tamper protection | Encrypt cardholder data, daily log review |
+| ISO/IEC 42001 | System documentation via chain | Management system around the technical component |
+| NIST AI RMF | Accountability traceability | Risk identification, stakeholder engagement |
+
+---
+
+## 13. How to use this document
+
+For a compliance officer evaluating Context Passport:
+
+1. Identify your applicable frameworks (most operators face 2-4).
+2. Read the relevant sections to understand the mapping.
+3. Build the operator-side controls and documentation listed under "What is still on the operator."
+4. Engage your legal counsel and (where applicable) your notified body or external auditor to confirm the mapping satisfies their interpretation.
+
+For a sales engineer responding to a buyer's compliance question:
+
+1. Confirm the buyer's framework.
+2. Point them at the relevant section of this doc.
+3. Be honest about gaps — Context Passport is a technical component; it does not constitute compliance on its own.
+4. Offer to introduce them to operator-side patterns documented in `docs/witness-log.md` and `docs/key-management.md`.
+
+For a regulator or auditor:
+
+1. The spec is open (CC0). You can inspect every aspect of it without vendor cooperation.
+2. The conformance test suite is publicly runnable. You can verify any claim of conformance.
+3. The reference implementations are open-source. You can run them yourself.
+4. Cross-implementation verification is supported by the conformance vectors.
+
+---
+
+## 14. What this document is not
+
+- **Legal advice.** This is a technical mapping, not a legal opinion.
+- **A compliance audit.** Mapping a spec to a regulation is not the same as auditing an operator's deployment.
+- **A guarantee of regulatory acceptance.** Specific regulators may have specific interpretations that differ from the analysis here.
+- **Static.** Regulations evolve. This document is non-normative and will be updated as significant new regulations emerge.
+
+If you find an error or omission in this mapping, please open a PR or issue at `github.com/contextpassport/spec`.
+
+---
+
+*Context Passport — design notes for implementers and compliance teams. Released under CC0 along with the rest of the specification.*

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,388 @@
+# Threat Model
+
+**Status:** Non-normative reference
+**Audience:** Security architects, implementation reviewers, anyone running a Context Passport pipeline in an adversarial environment
+**Companion to:** [SPEC.md §5 — Security considerations](../SPEC.md#5-security-considerations)
+
+---
+
+## Why this document exists
+
+A standard that does not state what it defends against, and what it does not, gets evaluated against an imagined threat model that may not match reality. Implementations underbuild because they assume the spec defends more than it does, or overbuild because they assume it defends less. Auditors flag both as deficiencies.
+
+This document states explicitly what Context Passport is designed to protect, against whom, and what defense-in-depth assumptions an implementer must layer on top.
+
+It is based on the threat-modeling pattern from [Microsoft STRIDE](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats) and the asset-adversary structure used by NIST SP 800-30 and the IETF security-considerations conventions.
+
+---
+
+## 1. Assets being protected
+
+In priority order:
+
+### A1 — Integrity of recorded events
+
+The bytes of a committed passport must not be modifiable after creation without detection. Modification includes changing a single field, removing a field, reordering fields within the JSON, or substituting a different payload entirely.
+
+**Why this matters:** the entire value proposition of a verifiable record collapses if records can be silently changed. Every regulatory and operational use case requires this.
+
+### A2 — Attribution of records to their creator
+
+Each record must be cryptographically attributable to the agent or operator that created it, in a way the creator cannot later repudiate.
+
+**Why this matters:** in any post-incident analysis, the question "who did this?" must have a verifiable answer that does not rely on operator claims.
+
+### A3 — Chronological ordering of records
+
+The chain of records must reflect the true causal order of events. An attacker must not be able to insert a record at an earlier point in the chain, reorder records, or backdate.
+
+**Why this matters:** reconstructing what happened in what order is the foundation of forensic analysis.
+
+### A4 — Independence of verification
+
+A third party must be able to verify A1-A3 without trusting the operator, the agent, or any single component. Verification must work offline, with no network call to a vendor, when given the records and the proof material.
+
+**Why this matters:** this is the property that distinguishes a verifiable record from an audit log. A log requires trusting the logger; a verifiable record does not.
+
+### A5 — Completeness of records (best-effort, not guaranteed)
+
+To the extent possible, the system surfaces signals when expected records are missing.
+
+**Why this matters:** see §5 on what Context Passport cannot guarantee. Completeness is a contractual and process property, not a cryptographic one.
+
+---
+
+## 2. Trust boundaries
+
+The Context Passport architecture has five trust boundaries. An adversary on the far side of any boundary can affect different aspects of the threat model.
+
+```
+                  ┌──────────────────────────────────────────────────┐
+                  │                                                  │
+                  │  Agent runtime                                   │
+                  │  (Trust boundary 1: agent vs. agent operator)    │
+                  │                                                  │
+                  └────────────────────┬─────────────────────────────┘
+                                       │
+                  ┌────────────────────▼─────────────────────────────┐
+                  │                                                  │
+                  │  Client SDK                                      │
+                  │  (Trust boundary 2: SDK vs. local environment)   │
+                  │                                                  │
+                  └────────────────────┬─────────────────────────────┘
+                                       │
+                  ┌────────────────────▼─────────────────────────────┐
+                  │                                                  │
+                  │  Network                                         │
+                  │  (Trust boundary 3: client vs. transit)          │
+                  │                                                  │
+                  └────────────────────┬─────────────────────────────┘
+                                       │
+                  ┌────────────────────▼─────────────────────────────┐
+                  │                                                  │
+                  │  Receiving server                                │
+                  │  (Trust boundary 4: client vs. operator)         │
+                  │                                                  │
+                  └────────────────────┬─────────────────────────────┘
+                                       │
+                  ┌────────────────────▼─────────────────────────────┐
+                  │                                                  │
+                  │  External anchor / Witness Log                   │
+                  │  (Trust boundary 5: operator vs. third party)    │
+                  │                                                  │
+                  └──────────────────────────────────────────────────┘
+```
+
+Each adversary in §3 operates on one side of one of these boundaries.
+
+---
+
+## 3. Adversaries
+
+### Adv-1: Modification attacker (downstream)
+
+A party with access to records *after* they have been created. They want to alter a stored record to misrepresent what happened.
+
+**Capability:** read and write access to record storage; cannot create new records signed by the original creator.
+
+**What the spec defends against this:** the hash chain (SPEC.md §3.4). Modifying any field changes the `payload_hash`, which breaks the `integrity_hash`, which breaks every subsequent record's `parent_hash`. Detection is mechanical.
+
+**What the spec adds with signature:** SPEC.md §3.2.7's signature defeats modification even on a single isolated record (no chain context needed).
+
+**Residual risk:** none, given client-side signing at creation time.
+
+### Adv-2: Forgery attacker
+
+A party who wants to inject false records claiming to come from a specific agent or operator.
+
+**Capability:** can submit arbitrary data to the receiving server.
+
+**What the spec defends against this:** with signature, the attacker must produce a valid Ed25519 (or other algorithm) signature over the envelope. Without the private key, they cannot. The receiving server validates the signature against the embedded public key and the key's known association with the claimed identity.
+
+**Residual risk:** if the private key is compromised (Adv-7), forgery is undetectable. Defense: HSM-bound keys, key rotation, revocation infrastructure (docs/key-management.md).
+
+### Adv-3: Omission attacker
+
+A party who controls record creation and wants to *not record* a specific event they would normally be expected to record.
+
+**Capability:** controls what the SDK calls; can choose not to emit certain commits.
+
+**What the spec defends against this:** **nothing direct.** SPEC.md §5.4 makes this explicit. No cryptographic system can force record creation.
+
+**What an operator can layer on top:**
+- Continuity expectations (contractual or regulatory)
+- Counterparty reconciliation (when the event involves a second party)
+- External attestation (the agent is monitored by an independent process that emits its own records)
+- Sequence numbers in a namespaced extension, with gap detection downstream
+
+**Residual risk:** real and significant for adversarial environments. A malicious agent operator can always omit. This is a fundamental property of any audit system, not a Context Passport-specific limitation.
+
+### Adv-4: Backdating attacker
+
+A party who creates a record but sets `event.timestamp` to an earlier time, claiming the event happened before it actually did.
+
+**Capability:** controls record creation; controls the timestamp field.
+
+**What the spec defends against this:** the embedded signature signs the timestamp (it's part of the canonical envelope). Modifying the timestamp after signing breaks the signature. But signing it with an early timestamp at creation time is permitted by the spec.
+
+**What an operator must layer on top:** external anchoring at creation time. If the `payload_hash` is submitted to OpenTimestamps (or a TSA, or Sigstore Rekor) at the moment of creation, the anchor proves the hash existed at the externally-attested time. A backdated record cannot have an external anchor from before the time it was actually created.
+
+**Residual risk:** without external anchoring, backdating is undetectable. With external anchoring at creation time, defeated.
+
+### Adv-5: Replay attacker
+
+A party who captures a legitimate record in transit and resubmits it, attempting to have it accepted as a fresh record.
+
+**Capability:** network observation or compromised intermediate; cannot modify the record itself (would invalidate signature).
+
+**What the spec defends against this:** the `id` field of a passport is unique (per the format `ctx_{unix_ms}_{6_hex_bytes}`). The receiving server SHOULD reject any commit with a duplicate `id`. This is operator-level defense, not strictly required by the spec, but every conformant implementation should do it.
+
+**Residual risk:** if the receiving server does not deduplicate, a replayed record produces a duplicate entry. Mitigated by requiring all conformant servers to deduplicate by `id`.
+
+### Adv-6: Compromised receiving server
+
+The operator's receiving server is compromised by an external attacker or insider. The attacker can read, write, and delete records.
+
+**Capability:** full control of stored records and the Witness Log signing process.
+
+**What the spec defends against this — partially:**
+
+- Past records that were already externally-anchored: cannot be modified without detection. The hash chain plus the external anchor make the historical record provable independent of the compromised server.
+- Past records with client-side signatures: cannot be forged because the attacker doesn't have the client's private key.
+- Future records: the compromised server can produce fraudulent records, signed with whatever key it controls. Detectable only if downstream consumers compare against a separately-witnessed chain (e.g., a customer-side mirror, a second Witness Log operator).
+
+**What the spec adds with the Witness Log:** docs/witness-log.md §8's threat model. The Witness Log's append-only, externally-anchored chain makes long-term silent compromise detectable. A compromised server cannot rewrite history without producing a visible fork in the published chain.
+
+**Residual risk:** real-time compromise of the receiving server allows producing fraudulent new records that may pass verification until the compromise is detected. Defense: multi-operator cross-witnessing (a second Witness Log operator countersigns or independently anchors).
+
+### Adv-7: Compromised signing key
+
+The agent's or operator's private signing key is exfiltrated. The attacker can produce records that verify as authentic.
+
+**Capability:** indistinguishable from the legitimate key holder at the cryptographic layer.
+
+**What the spec defends against this:** nothing at the cryptographic layer. A valid signature is valid.
+
+**What the operator must layer on top:**
+
+- Detection (anomaly detection on signing patterns, monitoring for unexpected key usage)
+- Revocation (docs/key-management.md §6)
+- Forward security through frequent rotation
+- HSM-bound keys that cannot be exfiltrated in the first place (the strongest defense)
+
+**Residual risk:** records produced between compromise and revocation are indistinguishable from legitimate records. Detection lag is the residual.
+
+### Adv-8: Malicious agent operator
+
+The operator who runs the agent is themselves the adversary. They want to produce records that look legitimate but represent a different reality than what the agent actually did.
+
+**Capability:** controls the agent runtime, the SDK, the keys, the receiving server, and the records.
+
+**What the spec defends against this — almost nothing:** if the operator controls all the parties, they can produce internally-consistent records that lie about what happened. This is the limit of any single-party verifiable-record system.
+
+**What defeats this:**
+- Counterparty records. If the action involves a second party (a payment processor, an MCP server operated by someone else, a regulator's witness), the second party's records are an independent witness.
+- External anchoring at creation time. Even an operator-controlled chain that is anchored externally cannot be retroactively edited; if the lie is discovered later, the operator cannot cover it by rewriting history.
+- Independent observation. A monitoring system (sandboxed, network-restricted) that observes the agent's actual behavior and produces its own records.
+
+**Residual risk:** real. The standard cannot protect against an operator who controls everything. The mitigation is structural — counterparty reconciliation, regulatory presence, external observers — not cryptographic.
+
+### Adv-9: Compromised OTS calendar or external anchoring service
+
+The external anchoring service (OpenTimestamps calendar, RFC 3161 TSA, Sigstore Rekor) is compromised or colludes with the operator.
+
+**Capability:** can claim a hash was anchored at a time other than when it actually was; can refuse to anchor; can publish anchors for hashes not submitted to it.
+
+**What the spec defends against this:** the spec recommends multiple independent anchoring services (docs/external-anchoring.md). A single compromised calendar is detectable if its claims diverge from other calendars' claims for the same hash.
+
+**For OpenTimestamps specifically:** the calendar is not the trust root. The Bitcoin blockchain is. A calendar can lie about timing only until its claimed anchor is checked against the actual Bitcoin block, at which point the lie is exposed. A calendar can refuse to anchor (denial of service), in which case operators should submit to multiple calendars.
+
+**Residual risk:** very low. Multi-calendar submission plus the Bitcoin trust root make this adversary effectively defeated.
+
+### Adv-10: Network attacker
+
+A party who can read, drop, modify, or inject network traffic between the client and the receiving server.
+
+**Capability:** full network control.
+
+**What the spec defends against this:** modification is detectable via signature and hash chain. Injection of forged records is defeated by signature requirement. Dropping records is undetectable at the cryptographic layer but visible as a delayed-receipt anomaly at the operator.
+
+**What every implementation must layer on top:**
+- TLS for the client-to-server transport (out of scope for the spec but mandatory)
+- Client-side persistence so dropped commits can be retried (docs/throughput-and-trust.md)
+- Server-side acknowledgment so clients know a record was received
+
+**Residual risk:** very low with TLS + retry semantics.
+
+### Adv-11: Coercion attacker
+
+A party with legal or physical power to compel the operator to produce or modify records on demand (subpoena, hostage situation, state-level pressure).
+
+**Capability:** can force the operator to do anything the operator could technically do.
+
+**What the spec defends against this — partially:**
+
+- Past externally-anchored records cannot be modified by the operator, even under coercion. The Bitcoin chain does not respond to subpoenas.
+- The operator can be compelled to produce records, but the records' integrity is independent of the operator's cooperation.
+
+**What the spec does not defend against:**
+- The operator can be compelled to stop producing records.
+- The operator can be compelled to disclose past records (though regulators usually want this).
+- The operator can be compelled to produce future records with a different schema or under duress, which downstream verifiers would have no way to distinguish from voluntary records.
+
+**Residual risk:** specific to high-coercion environments. Operators in such environments may need to implement "warrant canaries" or use additional cryptographic constructions outside the scope of this spec.
+
+---
+
+## 4. Severity ratings
+
+| Adversary | Spec defense | Severity if defense fails |
+|---|---|---|
+| Adv-1 Modification | Strong | Low (cryptographically defeated) |
+| Adv-2 Forgery | Strong with signature | Medium (depends on key protection) |
+| Adv-3 Omission | None | High (fundamental limit) |
+| Adv-4 Backdating | Strong with external anchor | Medium (without anchor) |
+| Adv-5 Replay | Operator-level deduplication | Low (mechanical defense) |
+| Adv-6 Compromised server | Witness Log helps | High in real-time, low for history |
+| Adv-7 Compromised key | None at crypto layer | High until revocation |
+| Adv-8 Malicious operator | Structural only | High in single-party, low with counterparty |
+| Adv-9 Compromised anchor | Multi-calendar defeats | Very low |
+| Adv-10 Network | TLS + retry | Very low |
+| Adv-11 Coercion | Partial (history preserved) | High for future records |
+
+---
+
+## 5. What Context Passport cannot defend against (concise)
+
+Restated for clarity:
+
+1. **Records the agent chose not to create.** Cryptography cannot reveal absence.
+2. **A fully-controlling malicious operator with no counterparty involvement.** All parts can be controlled; the lie is self-consistent.
+3. **Compromised signing keys, until revocation lands.** A valid signature is valid.
+4. **Coerced future-record production.** The operator can be forced to produce records that misrepresent reality going forward, with no cryptographic remedy.
+5. **Quantum-relevant adversaries.** Ed25519 and ECDSA are not post-quantum secure. Addressed in a future major version (docs/migration-and-versioning.md).
+
+For each, the mitigation is layered: contractual, structural, procedural, or future-spec. Implementers in adversarial environments must layer accordingly.
+
+---
+
+## 6. Defense-in-depth recommendations
+
+For implementers building production deployments, the following are not required by the spec but strongly recommended:
+
+### 6.1 Always sign
+
+Even though signature is optional in SPEC.md §3.2.7, treat it as required in production. The cost is small (a few hundred microseconds per commit); the benefit is defeating Adv-1, Adv-2, Adv-4 (with external anchor), and Adv-7's pre-compromise window.
+
+### 6.2 Always anchor externally
+
+OpenTimestamps is free. The latency is acceptable for almost all use cases (asynchronous; doesn't block commits). The defense against Adv-4 and Adv-6 is significant.
+
+### 6.3 Use HSM-bound keys for signing
+
+Defeats Adv-7's exfiltration vector. The key never leaves the secure enclave. The cost (KMS subscription or HSM hardware) is small relative to the threat reduction.
+
+### 6.4 Run a Witness Log with cross-party witnessing
+
+Defeats Adv-6 and reduces Adv-8 to "compromise the operator AND the cross-witness simultaneously," which is harder.
+
+### 6.5 Deduplicate by `id` at the receiving server
+
+Defeats Adv-5. Mechanical, low-cost, no excuse not to.
+
+### 6.6 Implement key rotation on a schedule
+
+Annual at minimum. Defeats long-term Adv-7 by limiting the window in which a compromised key can produce fraudulent records.
+
+### 6.7 Monitor for anomalies
+
+Pattern-based detection (signing rate, source IP, signing key, payload shape) catches Adv-7 faster than manual inspection. Out of scope for the spec; should be in every operator's runbook.
+
+### 6.8 Establish continuity expectations contractually
+
+Defeats Adv-3 by moving "omission" from "undetectable cryptographically" to "contractually auditable." Belongs in the operator's SLA with their customers and in customers' policies for their agents.
+
+---
+
+## 7. Threat-model assumptions stated explicitly
+
+The above analysis assumes:
+
+- **The hash function (SHA-256) is collision-resistant.** True today. If broken, the spec moves to a new hash in a major version (docs/migration-and-versioning.md).
+- **The signature algorithm (Ed25519) is forgery-resistant.** True today against classical adversaries; not post-quantum secure.
+- **TLS is configured correctly for client-to-server transport.** Out of scope; the operator's responsibility.
+- **The operator's storage layer is honest about append-only semantics.** Should be enforced at the database level, not just the application level.
+- **The operator's GPG key (for Witness Log signing) is not compromised.** If it is, see Adv-6.
+- **The external anchoring service (Bitcoin via OTS) is not subverted at the protocol level.** Treating Bitcoin's security as adequate for record-timestamping purposes is a widely-accepted assumption.
+
+If any of these assumptions fails in your environment, the corresponding defenses degrade. Operators are encouraged to document their own threat-model assumptions in their security documentation, referencing this document where helpful.
+
+---
+
+## 8. Comparison to related systems
+
+To calibrate expectations, here is how Context Passport's threat model compares to adjacent systems:
+
+| System | Defends modification | Defends forgery | Defends omission | Independent verification |
+|---|---|---|---|---|
+| Database audit log (no chain) | Operator-trusted only | Operator-trusted only | No | No |
+| Append-only DB (e.g. immudb) | Yes | Operator-trusted | No | Requires server cooperation |
+| Hash-chained log (e.g. AWS QLDB) | Yes | Operator-trusted | No | Requires AWS |
+| Certificate Transparency | Yes | Yes | No | Yes (the entire point) |
+| Sigstore Rekor | Yes | Yes | No | Yes |
+| Blockchain (Bitcoin) | Yes | Yes | No | Yes |
+| **Context Passport (this spec)** | **Yes** | **Yes (with signature)** | **No (fundamental)** | **Yes (with anchoring)** |
+
+Context Passport sits in the same architectural family as Certificate Transparency and Sigstore Rekor. The defense properties are essentially the same; the domain is different (agent execution records vs. TLS certificates vs. software artifacts).
+
+---
+
+## 9. How to use this document
+
+For a security review of a Context Passport deployment:
+
+1. Identify which adversaries are in scope for the deployment.
+2. For each in-scope adversary, confirm the corresponding defenses (cryptographic + operator-layered) are in place.
+3. For adversaries where the spec offers no direct defense (Adv-3, Adv-8, Adv-11), confirm the operator has layered structural defenses.
+4. Document the residual risk explicitly. Honest residual-risk documentation is itself a control.
+
+For a regulator evaluating Context Passport-based pipelines:
+
+1. The spec defends against the cryptographic adversaries (Adv-1, Adv-2, Adv-4, Adv-5, Adv-10) reliably.
+2. Operator-layered defenses are required for the operational adversaries (Adv-3, Adv-6, Adv-7, Adv-8, Adv-11).
+3. Verify both layers, not just the cryptographic one.
+
+For an SDK or implementation reviewer:
+
+1. Confirm the implementation does not introduce defects relative to the spec's defenses (e.g., a buggy canonicalization that weakens the hash chain).
+2. Confirm the implementation makes the defense-in-depth recommendations easy to enable (signature on by default in production, anchoring as an SDK feature, etc.).
+
+---
+
+## 10. Reporting a vulnerability
+
+If you discover a defect in the spec, a reference implementation, or this threat model, please report it privately to **security@darkmatterhub.ai** per `SECURITY.md`. We follow coordinated disclosure.
+
+---
+
+*Context Passport — design notes for implementers and security reviewers. Released under CC0 along with the rest of the specification.*


### PR DESCRIPTION
Two new reference docs. Regulatory-mapping does the field-by-field bridge from Context Passport to EU AI Act, FINRA, HIPAA, SOX, GDPR, PCI, ISO 42001, NIST AI RMF. Threat-model formally documents adversaries, defenses, and defense-in-depth. Non-normative. README updated.