### PR TITLE
v2.0: adopt RFC 8785 (JCS) canonicalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The envelope format for AI agent events.**
 
-Version 1.0 · Draft · Spec: CC0 1.0 · Reference implementations: Apache-2.0
+Version 2.0 · Spec: CC0 1.0 · Reference implementations: Apache-2.0
 
 ---
 
@@ -14,8 +14,8 @@ The goal: become the standard envelope format for AI agent events — a record a
 
 ```json
 {
-  "$schema": "https://contextpassport.com/schema/v1.json",
-  "schema_version": "1.0",
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
   "id": "ctx_1774358291224_bad9b976",
   "parent_id": "ctx_previous_or_null",
   "created_by": {
@@ -42,14 +42,16 @@ The goal: become the standard envelope format for AI agent events — a record a
 
 ## Contents
 
-- [`SPEC.md`](SPEC.md) — full specification
-- [`schema/v1.json`](schema/v1.json) — machine-readable JSON Schema
+- [`SPEC.md`](SPEC.md) — full specification (v2.0)
+- [`schema/v2.json`](schema/v2.json) — machine-readable JSON Schema (v2.0)
+- [`schema/v1.json`](schema/v1.json) — machine-readable JSON Schema (v1.x, retained for compatibility)
 - [`docs/`](docs/) — non-normative design notes for implementers
   - [`throughput-and-trust.md`](docs/throughput-and-trust.md) — submission patterns, trust properties, SDK guidance
   - [`external-anchoring.md`](docs/external-anchoring.md) — using OpenTimestamps (and alternatives) to anchor passports at creation time
   - [`key-management.md`](docs/key-management.md) — file-based, PKI/X.509, and DID-based signing key patterns
   - [`witness-log.md`](docs/witness-log.md) — operator architecture for publishing public, anchored checkpoint chains
   - [`migration-and-versioning.md`](docs/migration-and-versioning.md) — minor vs. major versions, cross-version compatibility, upgrade playbook
+  - [`migrations/v1-to-v2.md`](docs/migrations/v1-to-v2.md) — concrete operator playbook for the v1.x → v2.0 upgrade
   - [`regulatory-mapping.md`](docs/regulatory-mapping.md) — field-by-field mapping to EU AI Act, FINRA 17a-4, HIPAA, SOX, GDPR, PCI DSS, ISO/IEC 42001, NIST AI RMF
   - [`threat-model.md`](docs/threat-model.md) — adversaries, defenses, defense-in-depth recommendations
 - [`proposals/`](proposals/) — draft proposals
@@ -72,7 +74,7 @@ Third-party implementations are listed in [`IMPLEMENTATIONS.md`](IMPLEMENTATIONS
 
 ## Status
 
-Draft v1.0. The schema is stable enough to build against. We are collecting feedback before advancing to v1.0 final.
+v2.0. Adopts RFC 8785 (JCS) for cross-implementation byte-equivalence. Reference SDKs ship as `context-passport==2.0.x` on PyPI and `@contextpassport/core@2.0.x` on npm. v1.x records remain verifiable via the compatibility shim in both SDKs. See [`docs/migrations/v1-to-v2.md`](docs/migrations/v1-to-v2.md).
 
 Feedback welcome via GitHub Issues.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # Context Passport Specification
 
-**Version:** 1.0  
-**Status:** Stable for the v1.x line. Reference implementations are released as semver-stable (`context-passport==1.0.x` on PyPI, `@contextpassport/core@1.0.x` on npm). New features ship via the extension model (see `EXTENSIONS.md`) without breaking existing implementations. Breaking changes require a major version per `GOVERNANCE.md` and `docs/migration-and-versioning.md`.  
+**Version:** 2.0  
+**Status:** v2.0 adopts RFC 8785 (JSON Canonicalization Scheme) for hashing and signing, closing the cross-implementation portability gaps of v1.x. Reference implementations: `context-passport==2.0.x` on PyPI, `@contextpassport/core@2.0.x` on npm. v1.x records remain verifiable via the compatibility shim shipped with v2.x. Migration playbook in [`docs/migrations/v1-to-v2.md`](docs/migrations/v1-to-v2.md). New features ship via the extension model (see `EXTENSIONS.md`) without breaking existing implementations.  
 **Specification license:** CC0 1.0 Universal (public domain)  
 **Reference implementation license:** Apache-2.0 (with explicit patent grant)  
 **Maintained by:** Context Passport maintainers
@@ -250,32 +250,29 @@ else:
 integrity_hash   = "sha256:" + hex(sha256(chain_input))
 ```
 
-#### 3.4.1 Canonical-JSON algorithm (v1.x)
+#### 3.4.1 Canonical-JSON algorithm (v2.0)
 
-`canonical_json(value)` produces a deterministic UTF-8 byte sequence for any JSON value. v1.x of this specification defines the algorithm as follows:
+`canonical_json(value)` produces a deterministic UTF-8 byte sequence for any JSON value. v2.0 of this specification adopts [RFC 8785: JSON Canonicalization Scheme (JCS)](https://datatracker.ietf.org/doc/html/rfc8785) as the normative algorithm. All conformant v2.0 implementations MUST produce byte-identical output for the same input JSON value.
 
-1. **Key order.** Object keys are sorted at every level. Sort order is lexicographic by Unicode code point (equivalent to JavaScript's `Array.prototype.sort()` and Python's `sorted()` with default comparison on string keys).
-2. **No whitespace.** No spaces, tabs, or newlines between tokens. Equivalent to `JSON.stringify(value)` with no spacing arguments, or Python's `json.dumps(value, separators=(",", ":"))`.
-3. **String encoding.** Strings are encoded as UTF-8 bytes. Conformant implementations SHOULD emit non-ASCII characters as raw UTF-8 bytes (not `\uXXXX` escape sequences). Python implementations using `json.dumps` MUST pass `ensure_ascii=False` to comply.
-4. **Number formatting.** Numbers are serialized using each language's default JSON number serialization. This is the source of the v1.x portability gap noted below.
-5. **Output encoding.** The output is a UTF-8 byte sequence. The SHA-256 hash is computed over those bytes.
+In summary, JCS specifies:
 
-#### 3.4.2 Known portability limitations of v1.x
+1. **Key order.** Object keys are sorted at every level by UTF-16 code-unit order.
+2. **No whitespace.** No spaces, tabs, or newlines between tokens.
+3. **String escaping.** Only the seven JSON-mandated control-character escapes plus `"` and `\\`. All other Unicode characters are emitted as raw UTF-8 bytes.
+4. **Number formatting.** Per the ECMAScript `Number.prototype.toString` algorithm: integer-valued numbers serialize without a decimal point, negative zero collapses to `0`, trailing zeros are removed, and scientific notation is deterministic. `NaN` and `Infinity` are not representable and MUST be rejected.
+5. **Output encoding.** The output is a UTF-8 byte sequence. SHA-256 is computed over those bytes.
 
-The v1.x canonical-JSON algorithm produces byte-equivalent output across implementations for the common case of ASCII-only string payloads and integer values within JavaScript's safe-integer range. It does NOT produce byte-equivalent output across implementations for:
+Refer to RFC 8785 for the full algorithm. Reference implementations: [`jcs`](https://pypi.org/project/jcs/) (Python), [`canonicalize`](https://www.npmjs.com/package/canonicalize) (TypeScript). Either may be used; the reference SDKs implement JCS inline to avoid an extra dependency.
 
-- **Non-ASCII strings** when implementations differ on `ensure_ascii` behavior. Implementations conforming to this spec MUST emit raw UTF-8 (not `\uXXXX` escapes), but a 1.0.x record produced by an implementation that did not pass `ensure_ascii=False` will not verify under one that does, and vice versa.
-- **Numbers requiring more precision than JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 − 1).** JavaScript silently truncates such values. Records containing integers larger than 2^53 − 1 may not produce identical hashes across language implementations.
-- **Floating-point numbers.** Different language defaults for serializing floats (e.g., `1.0` vs `1`, scientific notation, precision) may produce different bytes.
+#### 3.4.2 Numeric range constraint
 
-**For v1.x portability,** applications SHOULD:
-- Limit payload string content to ASCII OR ensure all implementations they care about have `ensure_ascii=False` semantics.
-- Limit numeric values to integers in the range `[-(2^53 − 1), 2^53 − 1]`. Larger integers should be encoded as strings.
-- Avoid floating-point numbers in payloads where cross-implementation verification is required. Encode quantities at fixed precision as integers (e.g., cents instead of dollars).
+JCS specifies number serialization but cannot widen the range of numbers a host language can represent. Implementations in languages whose default number type is IEEE-754 double precision (e.g., JavaScript) cannot losslessly carry integers outside `[-(2^53 − 1), 2^53 − 1]`. Applications that need arbitrary-precision integer values MUST encode them as strings in the payload.
 
-#### 3.4.3 Future work
+#### 3.4.3 v1.x compatibility
 
-A future v2.0 of this specification will adopt [RFC 8785 (JSON Canonicalization Scheme)](https://datatracker.ietf.org/doc/html/rfc8785) as the canonicalization algorithm. RFC 8785 closes all three of the gaps above with a single well-defined algorithm. The proposal and migration path are documented at [`proposals/canonical-json-jcs.md`](proposals/canonical-json-jcs.md). The polyglot conformance harness at [`contextpassport/conformance-tests/runner/polyglot/`](https://github.com/contextpassport/conformance-tests/tree/main/runner/polyglot) tracks the v1.x divergences explicitly so that v2.0 adoption can be verified against the same payloads.
+v1.x records remain verifiable under v2.0 via the compatibility shim shipped in the reference implementations (`context_passport.compat.v1` in Python, `@contextpassport/core/compat/v1` in TypeScript). Verifiers dispatch per-record on `schema_version`: records carrying `"1.0"` or any other `"1.x"` value are hashed using the v1.x algorithm; everything else uses JCS. Mixed-version chains are valid and verify correctly.
+
+The v1.x canonical-JSON algorithm (sorted keys; `json.dumps(value, separators=(",", ":"))` in Python; `JSON.stringify` with a sorted-keys replacer in TypeScript) is retained in the shim solely for backwards compatibility. New implementations SHOULD NOT produce v1.x records.
 
 #### 3.4.4 Verification
 
@@ -291,13 +288,14 @@ If any comparison fails, the chain is `broken` at that point.
 
 ## 4. Conformance
 
-An implementation is **Context Passport v1.0 conformant** if it:
+An implementation is **Context Passport v2.0 conformant** if it:
 
-1. Produces passports that validate against the JSON Schema at `schema/v1.json`.
-2. Correctly computes the integrity block as defined in section 3.4.
+1. Produces passports that validate against the JSON Schema at `schema/v2.json`.
+2. Correctly computes the integrity block per section 3.4 using RFC 8785 (JCS).
 3. Correctly links parent commits via `parent_id`.
-4. Correctly verifies chains by recomputing hashes.
-5. Sets `schema_version: "1.0"` on all produced passports.
+4. Correctly verifies chains by recomputing hashes. For mixed-version chains, dispatches per-record on `schema_version` (v1.x records use the v1.x algorithm; v2.x records use JCS).
+5. Sets `schema_version: "2.0"` on all newly produced passports.
+6. Passes the polyglot conformance harness at [`contextpassport/conformance-tests`](https://github.com/contextpassport/conformance-tests).
 
 Conformant implementations are encouraged to list themselves in the implementations registry at `github.com/contextpassport/spec/IMPLEMENTATIONS.md`. A conformance test suite is published at `github.com/contextpassport/conformance-tests`. An implementation may declare itself conformant only after passing all required test vectors.
 

--- a/docs/migrations/v1-to-v2.md
+++ b/docs/migrations/v1-to-v2.md
@@ -1,0 +1,100 @@
+# Migrating from Context Passport v1.x to v2.0
+
+This guide is for operators of pipelines and SDK consumers upgrading from the v1.x line to v2.0. If you only consume v2.0 records from day one, you don't need this guide.
+
+## What changed
+
+v2.0 adopts **RFC 8785 (JSON Canonicalization Scheme / JCS)** as the canonical-JSON algorithm used for `payload_hash`, `integrity_hash`, and the signing envelope. Nothing else in the envelope changes.
+
+The fields, schema, and event types are unchanged. The semantics of `parent_id` linkage, `integrity_hash` derivation, and the signing block are unchanged. Only the byte-level serialization rule changed.
+
+## What that means in practice
+
+For payloads that are pure ASCII strings with integer values in `[-(2^53 − 1), 2^53 − 1]`, v1.x and v2.0 produce **identical bytes and identical hashes**. These records are byte-compatible across versions and need no migration.
+
+For payloads containing **non-ASCII characters**, **emoji**, **floats**, or **integers outside the safe range**, v1.x and v2.0 produce different bytes. A v1.x record will have a `payload_hash` that a v2.0 verifier will not naturally recompute unless it knows to apply the v1.x algorithm.
+
+## How to verify mixed-version chains
+
+The reference SDKs ship a `compat.v1` module. The top-level `verify_chain` dispatches per-record on `schema_version`:
+
+- `schema_version` starts with `"1."` → use the v1.x algorithm (via the compat shim).
+- Anything else → use JCS.
+
+This is automatic — no code change required for consumers who just call `verify_chain`. Mixed chains containing both v1.x and v2.0 records verify correctly.
+
+### Python
+
+```python
+from context_passport import verify_chain
+# Works for v1-only chains, v2-only chains, and mixed chains.
+ok = verify_chain([passport1, passport2, ...])
+
+# If you want explicit access to the v1 algorithm:
+from context_passport.compat import v1
+h = v1.payload_hash(legacy_payload)
+```
+
+### TypeScript
+
+```ts
+import { verifyChain } from "@contextpassport/core";
+const ok = verifyChain([passport1, passport2, ...]);
+
+import { payloadHash as v1PayloadHash } from "@contextpassport/core/compat/v1";
+const h = v1PayloadHash(legacyPayload);
+```
+
+## Operator playbook
+
+Follow the **chain reset** pattern from [`docs/migration-and-versioning.md`](../migration-and-versioning.md) §5.2.
+
+### Phase 1 — upgrade SDKs (no behavior change yet)
+
+Bump dependencies but pin to `schema_version: "1.0"` for newly produced records. The v2.x SDKs let you do this by passing the version explicitly if you need a freeze window. (In the default path, the SDK produces v2.0 records.) Verify that `verify_chain` over your existing v1.x records continues to return true. This proves the compat shim is wired up correctly.
+
+### Phase 2 — start the new chain
+
+Tag the v1.x → v2.0 boundary in your pipeline. For each agent, the next emitted record carries `schema_version: "2.0"` and `parent_id` pointing at the last v1.x record's `id`. Its `parent_hash` will be the v1.x record's `integrity_hash` — which was computed under v1.x rules and is preserved verbatim.
+
+The first v2.0 record after a v1.x parent is the *only* place where two algorithms meet in one verification: the verifier computes the parent record's `payload_hash` with the v1.x algorithm and the new record's `payload_hash` with JCS. The chain still verifies.
+
+### Phase 3 — drop v1.x writes
+
+Once all producers in your pipeline ship records with `schema_version: "2.0"`, you can stop carrying the compat shim's encoding *for new writes*. You still need it for *verification* of any v1.x records you've archived. The compat shim is part of the v2.x SDK indefinitely.
+
+### Phase 4 — re-anchor (optional)
+
+If you publish witness-log checkpoints (see [`docs/witness-log.md`](../witness-log.md)), your v2.0 checkpoints will start a new Merkle-tree chain. Existing checkpoints anchoring v1.x records remain valid; they just can't be extended.
+
+## What NOT to do
+
+- **Don't re-hash v1.x records under v2.0 rules.** That changes the record's `payload_hash` and `integrity_hash`, which breaks any existing signatures and any downstream system that referenced the v1.x hash. Leave v1.x records as-is and verify them with the v1.x algorithm via the compat shim.
+- **Don't bridge versions by recomputing.** If your archive contains a v1.x record with a non-ASCII payload, do not "translate" it to v2.0 by recomputing the hashes. The cryptographic chain anchors the bytes that were originally hashed.
+
+## Numbers larger than 2^53 − 1
+
+JCS specifies how numbers serialize but cannot widen the range of integers that JavaScript's `Number` type can represent. If your payloads contain identifiers larger than `Number.MAX_SAFE_INTEGER`, encode them as strings:
+
+```json
+{ "trade_id": "12345678901234567" }   // good — string
+{ "trade_id": 12345678901234567 }     // bad — loses precision in JS
+```
+
+This is the only payload shape that crosses the v1.x → v2.0 boundary with new advice: the previous spec suggested the same workaround, but it's now mandatory for byte-equivalence under JCS rather than a recommendation under v1.x.
+
+## Verification checklist
+
+- [ ] SDKs upgraded to v2.x (`pip install "context-passport>=2.0"`, `npm install @contextpassport/core@^2.0`)
+- [ ] Existing v1.x records still verify under `verify_chain` (compat shim wired up)
+- [ ] New records carry `schema_version: "2.0"` and `$schema` pointing to `https://contextpassport.com/schema/v2.json`
+- [ ] Polyglot conformance harness in your CI matrix returns exit 0
+- [ ] Integer fields above 2^53 − 1 (if any) are encoded as strings
+- [ ] If you sign records: signed v2.0 records verify in both Python and TypeScript SDKs
+
+## References
+
+- [RFC 8785: JSON Canonicalization Scheme (JCS)](https://datatracker.ietf.org/doc/html/rfc8785)
+- [`proposals/canonical-json-jcs.md`](../../proposals/canonical-json-jcs.md) — original adoption proposal
+- [`docs/migration-and-versioning.md`](../migration-and-versioning.md) — general versioning playbook
+- [`contextpassport/conformance-tests`](https://github.com/contextpassport/conformance-tests) — polyglot harness

--- a/v2.json
+++ b/v2.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://contextpassport.com/schema/v2.json",
+  "title": "Context Passport v2.0",
+  "description": "Open standard for structured, verifiable records of AI agent events. v2.0 adopts RFC 8785 (JCS) as the canonical-JSON algorithm for hashing and signing.",
+  "type": "object",
+  "required": ["schema_version", "id", "branch_key", "created_by", "event", "integrity", "created_at"],
+  "properties": {
+    "$schema":        { "type": "string" },
+    "schema_version": { "type": "string", "const": "2.0" },
+    "id": {
+      "type": "string",
+      "pattern": "^ctx_[0-9]+_[a-f0-9]+$",
+      "description": "Globally unique context ID. Format: ctx_{unix_ms}_{6 hex bytes}"
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "description": "ID of the previous context in the chain. Null for root commits."
+    },
+    "trace_id": {
+      "type": ["string", "null"],
+      "description": "Groups multiple commits into a single pipeline run."
+    },
+    "branch_key": {
+      "type": "string",
+      "default": "main",
+      "description": "Branch name. Default: main. Used to distinguish fork branches."
+    },
+    "created_by": {
+      "type": "object",
+      "required": ["agent_id", "agent_name"],
+      "properties": {
+        "agent_id":   { "type": "string" },
+        "agent_name": { "type": "string" },
+        "role": {
+          "type": ["string", "null"],
+          "examples": ["researcher", "writer", "reviewer", "critic", "planner", "executor", "validator"]
+        },
+        "provider": {
+          "type": ["string", "null"],
+          "examples": ["anthropic", "openai", "google", "mistral", "local", "custom"]
+        },
+        "model": { "type": ["string", "null"] }
+      }
+    },
+    "event": {
+      "type": "object",
+      "required": ["type", "timestamp"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "examples": ["commit", "fork", "checkpoint", "revert", "branch", "merge",
+                       "spawn", "retry", "timeout", "error",
+                       "override", "consent", "escalate", "redact", "audit"]
+        },
+        "to_agent_id": { "type": ["string", "null"] },
+        "timestamp":   { "type": "string", "format": "date-time" }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "input":     { "description": "What this agent received." },
+        "output":    { "description": "What this agent produced. Prefer structured JSON." },
+        "memory":    { "type": ["object", "null"], "description": "Persistent state and config." },
+        "variables": { "type": ["object", "null"], "description": "Named values for downstream agents." }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "required": ["payload_hash", "integrity_hash", "verification_status"],
+      "properties": {
+        "payload_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "sha256(JSON.stringify(payload, sorted_keys))"
+        },
+        "parent_hash": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "integrity_hash of parent commit. Null for root."
+        },
+        "integrity_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "sha256(payload_hash + parent_hash)"
+        },
+        "verification_status": {
+          "type": "string",
+          "enum": ["valid", "broken", "unverified"]
+        },
+        "verified_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "properties": {
+        "fork_of":      { "type": ["string", "null"] },
+        "fork_point":   { "type": ["string", "null"] },
+        "lineage_root": { "type": ["string", "null"] }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "description": "Optional. Provides non-repudiation when present. See SPEC.md section 3.2.7.",
+      "required": ["algorithm", "key_id", "signature"],
+      "properties": {
+        "algorithm":  { "type": "string", "examples": ["ed25519", "ecdsa-p256", "rsa-pss-sha256"] },
+        "key_id":     { "type": "string" },
+        "public_key": { "type": ["string", "null"], "description": "Base64-encoded public key or a reference (DID, URL)." },
+        "signature":  { "type": "string", "description": "Base64-encoded signature over the canonical envelope with signature.signature cleared." }
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}


### PR DESCRIPTION
Closes the v1.x cross-implementation portability gaps. Polyglot harness passes 11/11. See docs/migrations/v1-to-v2.md.