### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a defect in the spec, schema, or reference behavior.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the defect you found.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What should happen according to the spec or intended behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: input
+    id: spec-version
+    attributes:
+      label: Spec version
+      description: Which spec version, commit, or release are you using?
+      placeholder: "v0.1.0, main@<commit>, or unknown"
+    validations:
+      required: true
+  - type: input
+    id: reference-implementation-tested
+    attributes:
+      label: Reference implementation tested
+      description: Which reference implementation, SDK, or validator did you test?
+      placeholder: "name/version, commit, or not tested"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction steps
+      description: List the smallest set of steps needed to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     attributes:
       label: Spec version
       description: Which spec version, commit, or release are you using?
-      placeholder: "v0.1.0, main@<commit>, or unknown"
+      placeholder: "v2.0, main@<commit>, or unknown"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Spec question / open discussion
+    url: https://github.com/contextpassport/spec/discussions
+    about: Ask usage questions or start an open-ended spec discussion.
+  - name: Security vulnerability
+    url: https://github.com/contextpassport/spec/blob/main/SECURITY.md
+    about: Review the security policy before reporting a vulnerability.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an addition or improvement to Context Passport.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: What user, implementer, or interoperability problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: What alternatives or workarounds have you considered?
+    validations:
+      required: false
+  - type: dropdown
+    id: willing-to-implement
+    attributes:
+      label: Willing to implement?
+      description: Are you willing to open a pull request for this change?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe, with guidance"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,43 @@
+name: RFC
+description: Propose and discuss a compatibility-affecting spec change.
+title: "RFC: "
+labels:
+  - rfc
+body:
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: What limitation, ambiguity, or interoperability problem motivates this RFC?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: Describe the spec change in enough detail for reviewers to evaluate it.
+    validations:
+      required: true
+  - type: textarea
+    id: backward-compatibility-analysis
+    attributes:
+      label: Backward compatibility analysis
+      description: Explain how existing passports, schemas, validators, or implementations would be affected.
+    validations:
+      required: true
+  - type: input
+    id: reference-implementation-link
+    attributes:
+      label: Reference implementation link
+      description: Link to an implementation, prototype, test fixture, or proof of concept if available.
+      placeholder: "https://github.com/..."
+    validations:
+      required: false
+  - type: input
+    id: requested-review-window
+    attributes:
+      label: Requested review window
+      description: When do you need feedback, and how long should the review window remain open?
+      placeholder: "e.g. 2 weeks, by 2026-06-15"
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Add GitHub issue forms for bug reports, feature requests, and RFCs.
- Disable blank issues and route general questions/security reports to the requested links.

This PR was prepared with AI assistance under human supervision. I kept the change small and included the checks I ran below.

## Checks
- `git diff --check`
- Parsed all `.github/ISSUE_TEMPLATE/*.yml` files with PyYAML.

Closes #17