### PR TITLE
docs: add example context passports

### DIFF
--- a/examples/chained.json
+++ b/examples/chained.json
@@ -1,0 +1,128 @@
+[
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358291000_a1b2c3d4e5f6",
+    "parent_id": null,
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-researcher-01",
+      "agent_name": "Research Agent",
+      "role": "researcher",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "commit",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:00:00Z"
+    },
+    "payload": {
+      "input": "Collect public launch notes for Project Atlas.",
+      "output": {
+        "summary": "Found release notes, pricing FAQ, and support article.",
+        "confidence": 0.91,
+        "sources": [
+          "release-notes.md",
+          "pricing-faq.md"
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
+      "parent_hash": null,
+      "integrity_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
+      "verification_status": "valid",
+      "verified_at": "2026-03-29T10:00:00Z"
+    },
+    "created_at": "2026-03-29T10:00:00Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358350000_b2c3d4e5f6a1",
+    "parent_id": "ctx_1774358291000_a1b2c3d4e5f6",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-writer-01",
+      "agent_name": "Writer Agent",
+      "role": "writer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "commit",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:12:30Z"
+    },
+    "payload": {
+      "input": {
+        "summary": "Found release notes, pricing FAQ, and support article.",
+        "confidence": 0.91,
+        "sources": [
+          "release-notes.md",
+          "pricing-faq.md"
+        ]
+      },
+      "output": {
+        "draft": "Customer-facing launch summary prepared.",
+        "open_questions": [
+          "Confirm enterprise support SLA wording."
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:0108fdadbad542e6b59c86f3c4eb05669dd84ba5d84b7601fdffde7b344d6b5d",
+      "parent_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
+      "integrity_hash": "sha256:9a3e149448d9dd044716c7571af203492b13f3d75e9e69d8c75233ffd95d03d4",
+      "verification_status": "valid",
+      "verified_at": "2026-03-29T10:12:30Z"
+    },
+    "created_at": "2026-03-29T10:12:30Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358460000_c3d4e5f6a1b2",
+    "parent_id": "ctx_1774358350000_b2c3d4e5f6a1",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-reviewer-01",
+      "agent_name": "Reviewer Agent",
+      "role": "reviewer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "checkpoint",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:31:00Z"
+    },
+    "payload": {
+      "input": {
+        "draft": "Customer-facing launch summary prepared.",
+        "open_questions": [
+          "Confirm enterprise support SLA wording."
+        ]
+      },
+      "output": {
+        "decision": "approved_with_minor_edits",
+        "notes": [
+          "Remove unverifiable adoption metric.",
+          "Keep pricing language source-backed."
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:3eb2fcd7fa14ffc8b7bab54667ffdc68263da2e403ac0ddfe78065adb0f8b34f",
+      "parent_hash": "sha256:9a3e149448d9dd044716c7571af203492b13f3d75e9e69d8c75233ffd95d03d4",
+      "integrity_hash": "sha256:2e8ce0201b5558f4acb75734f791c2d08f6e3c277e70577b75142019e18c476c",
+      "verification_status": "valid",
+      "verified_at": "2026-03-29T10:31:00Z"
+    },
+    "created_at": "2026-03-29T10:31:00Z"
+  }
+]

--- a/examples/chained.json
+++ b/examples/chained.json
@@ -32,7 +32,7 @@
     "integrity": {
       "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
       "parent_hash": null,
-      "integrity_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
+      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
       "verification_status": "valid",
       "verified_at": "2026-03-29T10:00:00Z"
     },
@@ -75,8 +75,8 @@
     },
     "integrity": {
       "payload_hash": "sha256:0108fdadbad542e6b59c86f3c4eb05669dd84ba5d84b7601fdffde7b344d6b5d",
-      "parent_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
-      "integrity_hash": "sha256:9a3e149448d9dd044716c7571af203492b13f3d75e9e69d8c75233ffd95d03d4",
+      "parent_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
+      "integrity_hash": "sha256:44350101059afdf7ac0222e271ada4cfc04ccb0a617eddd5caabaacea08a162d",
       "verification_status": "valid",
       "verified_at": "2026-03-29T10:12:30Z"
     },
@@ -118,8 +118,8 @@
     },
     "integrity": {
       "payload_hash": "sha256:3eb2fcd7fa14ffc8b7bab54667ffdc68263da2e403ac0ddfe78065adb0f8b34f",
-      "parent_hash": "sha256:9a3e149448d9dd044716c7571af203492b13f3d75e9e69d8c75233ffd95d03d4",
-      "integrity_hash": "sha256:2e8ce0201b5558f4acb75734f791c2d08f6e3c277e70577b75142019e18c476c",
+      "parent_hash": "sha256:44350101059afdf7ac0222e271ada4cfc04ccb0a617eddd5caabaacea08a162d",
+      "integrity_hash": "sha256:b884301cb2a7d1722095760806b502bd3ac4aaf034bfb58d67185bc4287acae5",
       "verification_status": "valid",
       "verified_at": "2026-03-29T10:31:00Z"
     },

--- a/examples/signed.json
+++ b/examples/signed.json
@@ -31,7 +31,7 @@
   "integrity": {
     "payload_hash": "sha256:5c0f1239de654ec7231d7c1f29788ab31112bde0dbae55635e0d2cf4e9050246",
     "parent_hash": null,
-    "integrity_hash": "sha256:96067f67d5f25a1e5d68dece39e8d631e3dbf6860b585cf7e2065b6968cb05bb",
+    "integrity_hash": "sha256:023d12cccdb6611f57038dd2174765f362b3feace7fb8df2f0813b637493168a",
     "verification_status": "valid",
     "verified_at": "2026-03-29T11:00:00Z"
   },
@@ -39,7 +39,7 @@
   "signature": {
     "algorithm": "ed25519",
     "key_id": "did:example:contextpassport#demo-key-1",
-    "public_key": "MCowBQYDK2VwAyEAu7zDemoPublicKeyForDocsOnlyExample1234567890=",
-    "signature": "MEUCIQDemoSignatureForDocumentationOnlyNotACryptographicProof=="
+    "public_key": "LeBaZ8Bgmwex3N2vGFE/ot5fZxXl+sQ/WMtZxEh07rE=",
+    "signature": "YA2cYGVFrNU1fr7SGeQbIwvZp4T0hpf3qT0ZZkEwG5sx7bqu0zP8cgPr4AOYUbKwXFelmdYXF02O+I2tiO+dAA=="
   }
 }

--- a/examples/signed.json
+++ b/examples/signed.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774359000000_d4e5f6a1b2c3",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-auditor-01",
+    "agent_name": "Audit Agent",
+    "role": "auditor",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "audit",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T11:00:00Z"
+  },
+  "payload": {
+    "input": "Review launch summary chain for source-backed claims.",
+    "output": {
+      "status": "passed",
+      "checked_contexts": [
+        "ctx_1774358291000_a1b2c3d4e5f6",
+        "ctx_1774358350000_b2c3d4e5f6a1",
+        "ctx_1774358460000_c3d4e5f6a1b2"
+      ]
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:5c0f1239de654ec7231d7c1f29788ab31112bde0dbae55635e0d2cf4e9050246",
+    "parent_hash": null,
+    "integrity_hash": "sha256:96067f67d5f25a1e5d68dece39e8d631e3dbf6860b585cf7e2065b6968cb05bb",
+    "verification_status": "valid",
+    "verified_at": "2026-03-29T11:00:00Z"
+  },
+  "created_at": "2026-03-29T11:00:00Z",
+  "signature": {
+    "algorithm": "ed25519",
+    "key_id": "did:example:contextpassport#demo-key-1",
+    "public_key": "MCowBQYDK2VwAyEAu7zDemoPublicKeyForDocsOnlyExample1234567890=",
+    "signature": "MEUCIQDemoSignatureForDocumentationOnlyNotACryptographicProof=="
+  }
+}

--- a/examples/single-commit.json
+++ b/examples/single-commit.json
@@ -31,7 +31,7 @@
   "integrity": {
     "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
     "parent_hash": null,
-    "integrity_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
+    "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
     "verification_status": "valid",
     "verified_at": "2026-03-29T10:00:00Z"
   },

--- a/examples/single-commit.json
+++ b/examples/single-commit.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358291000_a1b2c3d4e5f6",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-researcher-01",
+    "agent_name": "Research Agent",
+    "role": "researcher",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "commit",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T10:00:00Z"
+  },
+  "payload": {
+    "input": "Collect public launch notes for Project Atlas.",
+    "output": {
+      "summary": "Found release notes, pricing FAQ, and support article.",
+      "confidence": 0.91,
+      "sources": [
+        "release-notes.md",
+        "pricing-faq.md"
+      ]
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
+    "parent_hash": null,
+    "integrity_hash": "sha256:376a91e198820768759b43fa2200bb8a27ebb3e39d333ed046b294470a67cb69",
+    "verification_status": "valid",
+    "verified_at": "2026-03-29T10:00:00Z"
+  },
+  "created_at": "2026-03-29T10:00:00Z"
+}

--- a/examples/with-extensions.json
+++ b/examples/with-extensions.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774359600000_e5f6a1b2c3d4",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-billing-reviewer-01",
+    "agent_name": "Billing Review Agent",
+    "role": "billing-reviewer",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "checkpoint",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T11:10:00Z"
+  },
+  "payload": {
+    "input": "Verify payment approval metadata before fulfillment.",
+    "output": {
+      "decision": "hold_for_invoice_match"
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:0ffa7a47f84b1808822fde9ad7b9ecfff5cc75dd15e572fe25bc022b2970b781",
+    "parent_hash": null,
+    "integrity_hash": "sha256:a6588107c1ee8afe9209b8f2e08dbcfd42b44ba0cf5e4a6fe5e94efda2e94900",
+    "verification_status": "valid",
+    "verified_at": "2026-03-29T11:10:00Z"
+  },
+  "created_at": "2026-03-29T11:10:00Z",
+  "extensions": {
+    "acme.payment_amount": 12500,
+    "acme.currency": "USD",
+    "acme.invoice_id": "INV-2026-0042"
+  }
+}

--- a/examples/with-extensions.json
+++ b/examples/with-extensions.json
@@ -26,7 +26,7 @@
   "integrity": {
     "payload_hash": "sha256:0ffa7a47f84b1808822fde9ad7b9ecfff5cc75dd15e572fe25bc022b2970b781",
     "parent_hash": null,
-    "integrity_hash": "sha256:a6588107c1ee8afe9209b8f2e08dbcfd42b44ba0cf5e4a6fe5e94efda2e94900",
+    "integrity_hash": "sha256:e76998e3108365887fec3674c5d0edfdaeca57d5a83971ffb552d0440b83bb14",
     "verification_status": "valid",
     "verified_at": "2026-03-29T11:10:00Z"
   },


### PR DESCRIPTION
## Summary
- add an examples/ directory for the README link
- include single-commit, chained, signed, and namespaced-extension context passport examples
- target the current v2.0 schema used by this repo

Closes #13.

## Checks
- git diff --check
- example passport structure/linkage assertion
- schema validation against schema/v2.json with jsonschema