### PR TITLE
schema: validate the shape of event types (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ breaking, which is exactly what happened in 2.0.
 Nothing in this section changes the wire format. Records written against 2.0
 are unaffected.
 
+### Changed
+
+- `schema/v2.json`: `event.type` now carries the pattern
+  `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`, enforcing as validation the shape
+  §3.3 always described: lowercase letters/digits/underscore segments joined
+  by dots (#35). Not breaking under this file's definition — no hashed bytes
+  change and every specified type matches — but records from implementations
+  that ignored the naming guidance may now fail schema validation.
+
 ## [2.0] - 2026-05-19
 
 ### Changed

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,7 +230,11 @@ Implementations that omit the signature block produce passports with tamper evid
 #### Compliance events
 `override` `consent` `escalate` `redact` `audit`
 
-Custom event types are permitted. Implementations SHOULD prefix custom types with a namespace: `myorg.custom_type`.
+Custom event types are permitted. Every event type MUST match the pattern
+`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`: one or more lowercase segments, each
+starting with a letter, followed by lowercase letters, digits or underscores,
+joined by single dots. Implementations SHOULD additionally prefix custom types
+with a namespace: `myorg.custom_type`.
 
 ### 3.4 Integrity computation
 

--- a/schema/v2.json
+++ b/schema/v2.json
@@ -49,6 +49,7 @@
       "properties": {
         "type": {
           "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
           "examples": ["commit", "fork", "checkpoint", "revert", "branch", "merge",
                        "spawn", "retry", "timeout", "error",
                        "override", "consent", "escalate", "redact", "audit"]


### PR DESCRIPTION
Closes #35

## What

- `schema/v2.json`: added `"pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"` to `event.type` (`examples` kept as documentation)
- `SPEC.md` §3.3: shape is now normative (**MUST**); namespace prefixing stays **SHOULD**
- `CHANGELOG.md`: added `[Unreleased] > Changed` entry with breaking-change classification

## Why

`examples` is annotation-only in JSON Schema, so before this change any string
validated — including `""`, `"Not A Type"`, `.leading_dot`. The pattern enforces
the *shape* without closing membership: custom namespaced types like
`acme.risk_review` stay permitted.

## Breaking?

No, per CHANGELOG.md's own definition (breaking = changes the bytes that get
hashed). No hashed bytes change. Records from implementations that ignored the
§3.3 naming guidance may now fail schema validation.

## Verification

- `npm test`: 9/9 example files pass
- All 15 specified types match the pattern; `acme.risk_review` matches
- Rejected: `""`, `"Not A Type"`, `".leading_dot"`, `trailing.`, `double..dot`, `"UPPER"`, `"9start"`, `"_under"`