### PR TITLE
docs: TypeScript version of the quickstart, checked by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,10 @@ jobs:
       # record breaks it). Assert those rather than trusting prose nobody has
       # run since it was written.
       - run: python tools/check-quickstart.py
+      # Same contract for the TypeScript quickstart: extract its blocks, run
+      # them against the published SDK, assert the documented booleans.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install --no-save @contextpassport/core@^2.0.0 tsx
+      - run: node tools/check-quickstart-ts.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# Temp dirs created by tools/check-quickstart-ts.mjs
+.tmp-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ breaking, which is exactly what happened in 2.0.
 Nothing in this section changes the wire format. Records written against 2.0
 are unaffected.
 
+### Changed
+
+- `schema/v2.json`: `event.type` now carries the pattern
+  `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`, enforcing as validation the shape
+  §3.3 always described: lowercase letters/digits/underscore segments joined
+  by dots (#35). Not breaking under this file's definition — no hashed bytes
+  change and every specified type matches — but records from implementations
+  that ignored the naming guidance may now fail schema validation.
+
 ## [2.0] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The goal: become the standard envelope format for AI agent events — a record a
 ## Contents
 
 - [`docs/quickstart.md`](docs/quickstart.md) — five minutes from install to a verified chain
+- [`docs/quickstart-typescript.md`](docs/quickstart-typescript.md) — the same quickstart for the TypeScript SDK
 - [`SPEC.md`](SPEC.md) — full specification (v2.0)
 - [`schema/v2.json`](schema/v2.json) — machine-readable JSON Schema (v2.0)
 - [`schema/v1.json`](schema/v1.json) — machine-readable JSON Schema (v1.x, retained for compatibility)

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,7 +230,11 @@ Implementations that omit the signature block produce passports with tamper evid
 #### Compliance events
 `override` `consent` `escalate` `redact` `audit`
 
-Custom event types are permitted. Implementations SHOULD prefix custom types with a namespace: `myorg.custom_type`.
+Custom event types are permitted. Every event type MUST match the pattern
+`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`: one or more lowercase segments, each
+starting with a letter, followed by lowercase letters, digits or underscores,
+joined by single dots. Implementations SHOULD additionally prefix custom types
+with a namespace: `myorg.custom_type`.
 
 ### 3.4 Integrity computation
 

--- a/docs/quickstart-typescript.md
+++ b/docs/quickstart-typescript.md
@@ -1,0 +1,108 @@
+# Quickstart (TypeScript)
+
+Zero to a verified chain in about five minutes, in TypeScript. Every block
+below is part of one script and runs as written. The Python SDK walkthrough
+is at [`quickstart.md`](quickstart.md).
+
+## Install
+
+```bash
+npm install @contextpassport/core@^2.0.0
+```
+
+## 1. Record something
+
+A passport is a record of one agent event. The payload is yours; the format
+only cares that it is JSON.
+
+```typescript
+import { makePassport, verifyChain } from "@contextpassport/core";
+
+const first = makePassport({
+  agentId: "agent-underwriter-01",
+  agentName: "Underwriting Agent",
+  payload: {
+    input: "Assess application APP-4471 against the lending policy.",
+    output: { decision: "decline", confidence: 0.88 },
+  },
+  role: "executor",
+  provider: "anthropic",
+  model: "claude-sonnet-5",
+  traceId: "trace_app_4471",
+});
+
+console.log(first.id);
+console.log(first.integrity.payload_hash);
+```
+
+`payload_hash` is the SHA-256 of the payload after RFC 8785 canonicalization.
+Two implementations in two languages produce the same bytes, so they produce
+the same hash.
+
+## 2. Chain a second record onto it
+
+Pass the previous passport as `parent`. That is the whole chaining API.
+
+```typescript
+const second = makePassport({
+  agentId: "human:reviewer_2c9d",
+  agentName: "Senior Credit Officer",
+  payload: {
+    input: "Review declined application APP-4471.",
+    output: { decision: "approve", reason: "Verified rental history." },
+  },
+  parent: first,
+  role: "compliance",
+  eventType: "override",
+  traceId: "trace_app_4471",
+});
+
+const chain = [first, second];
+console.log(second.integrity.parent_hash === first.integrity.integrity_hash);
+```
+
+That prints `true`. The child commits to the parent's `integrity_hash`, which
+is what makes the sequence tamper-evident rather than merely ordered.
+
+## 3. Verify
+
+```typescript
+console.log(verifyChain(chain));
+```
+
+`true`. Verification needs nothing but the records themselves: no server, no
+network, no trust in whoever wrote them.
+
+## 4. Break it on purpose
+
+This is the part worth seeing for yourself. Edit the first record's output, as
+someone rewriting history after the fact would.
+
+```typescript
+(chain[0].payload.output as { decision: string }).decision = "approve";
+
+console.log(verifyChain(chain));
+```
+
+`false`. Changing the payload changes its `payload_hash`, which no longer
+matches the `parent_hash` the second record committed to. The edit is not
+prevented, it is **detected**, and detected by anyone holding the records.
+
+Put it back and it verifies again:
+
+```typescript
+(chain[0].payload.output as { decision: string }).decision = "decline";
+
+console.log(verifyChain(chain));
+```
+
+## Where to go next
+
+- [`examples/`](../examples) has worked records for each event type, including
+  the compliance ones: `consent`, `override`, `escalate`, `redact`, `audit`.
+- [`SPEC.md`](../SPEC.md) section 3.4 defines the hashing rules precisely.
+- Signing records with Ed25519 via the SDK's `generateKeypair`/`signPassport`,
+  so a verifier also learns *who* wrote them, is covered in
+  [`docs/key-management.md`](key-management.md).
+- [contextpassport/typescript](https://github.com/contextpassport/typescript)
+  is the full TypeScript reference implementation.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
 # Quickstart
 
 Zero to a verified chain in about five minutes, in Python. Every block below is
-part of one script and runs as written. The TypeScript SDK has the same shape
-if you prefer it.
+part of one script and runs as written. A TypeScript version of this walkthrough
+lives at [`quickstart-typescript.md`](quickstart-typescript.md).
 
 ## Install
 

--- a/schema/v2.json
+++ b/schema/v2.json
@@ -49,6 +49,7 @@
       "properties": {
         "type": {
           "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
           "examples": ["commit", "fork", "checkpoint", "revert", "branch", "merge",
                        "spawn", "retry", "timeout", "error",
                        "override", "consent", "escalate", "redact", "audit"]

--- a/tools/check-quickstart-ts.mjs
+++ b/tools/check-quickstart-ts.mjs
@@ -24,7 +24,7 @@ const DOC = join(ROOT, "docs", "quickstart-typescript.md");
 //   parent_hash linkage, verify, verify after tampering, verify after undo.
 const EXPECTED_BOOLS = ["true", "true", "false", "true"];
 
-const blocks = [...readFileSync(DOC, "utf8").matchAll(/```typescript\n(.*?)```/gs)].map((m) => m[1]);
+const blocks = [...readFileSync(DOC, "utf8").replace(/\r\n/g, "\n").matchAll(/```typescript\n(.*?)```/gs)].map((m) => m[1]);
 if (blocks.length === 0) {
   console.error("No typescript blocks found in docs/quickstart-typescript.md");
   process.exit(1);

--- a/tools/check-quickstart-ts.mjs
+++ b/tools/check-quickstart-ts.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Runs docs/quickstart-typescript.md and checks it still says what actually happens.
+ *
+ * Twin of tools/check-quickstart.py: extracts the typescript blocks from the
+ * document, runs them as one script via tsx, and asserts the documented results
+ * (the chain verifies; editing a record breaks it; undoing restores it) rather
+ * than trusting prose nobody has run since it was written.
+ *
+ * Requires @contextpassport/core@^2 and tsx (CI installs both with --no-save):
+ *
+ *     node tools/check-quickstart-ts.mjs
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DOC = join(ROOT, "docs", "quickstart-typescript.md");
+
+// The boolean lines the document tells the reader to expect, in order:
+//   parent_hash linkage, verify, verify after tampering, verify after undo.
+const EXPECTED_BOOLS = ["true", "true", "false", "true"];
+
+const blocks = [...readFileSync(DOC, "utf8").matchAll(/```typescript\n(.*?)```/gs)].map((m) => m[1]);
+if (blocks.length === 0) {
+  console.error("No typescript blocks found in docs/quickstart-typescript.md");
+  process.exit(1);
+}
+
+// The extracted script must live inside the repo tree so that ESM resolution
+// finds this repo's node_modules (@contextpassport/core) regardless of cwd,
+// and must be .mts because this repo's package.json is not type: module.
+const dir = mkdtempSync(join(ROOT, ".tmp-qsts-"));
+let result;
+try {
+  const script = join(dir, "quickstart.mts");
+  writeFileSync(script, blocks.join("\n"), "utf8");
+  result = spawnSync(process.execPath, ["--import", "tsx", script], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+if (result.error) {
+  console.error(String(result.error));
+  console.error("Is tsx installed? CI does: npm install --no-save @contextpassport/core@^2.0.0 tsx");
+  process.exit(1);
+}
+if (result.status !== 0) {
+  console.log(result.stdout);
+  console.error(result.stderr);
+  console.error("docs/quickstart-typescript.md does not run as written");
+  process.exit(1);
+}
+
+const lines = result.stdout.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+
+// Exactly six lines of output: id, payload hash, then the four booleans.
+// Anything else means the document's code no longer prints what it claims.
+if (lines.length !== EXPECTED_BOOLS.length + 2) {
+  console.error("Output was:\n  " + lines.join("\n  "));
+  console.error(
+    `docs/quickstart-typescript.md runs, but printed ${lines.length} lines ` +
+      `(expected ${EXPECTED_BOOLS.length + 2})`,
+  );
+  process.exit(1);
+}
+
+const bools = lines.filter((l) => l === "true" || l === "false");
+if (bools.join() !== EXPECTED_BOOLS.join()) {
+  console.error("Output was:\n  " + lines.join("\n  "));
+  console.error(
+    "docs/quickstart-typescript.md runs, but its results changed.\n" +
+      `  expected booleans: ${EXPECTED_BOOLS.join(", ")}\n` +
+      `  actual:            ${bools.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+if (!lines[0].startsWith("ctx_")) {
+  console.error(`Expected the first printed line to be a passport id, got: ${lines[0]}`);
+  process.exit(1);
+}
+if (!lines[1].startsWith("sha256:")) {
+  console.error(`Expected the second printed line to be a payload hash, got: ${lines[1]}`);
+  process.exit(1);
+}
+
+console.log(
+  `docs/quickstart-typescript.md runs as written: ${blocks.length} blocks, results as documented.`,
+);


### PR DESCRIPTION
Closes #34

Adds `docs/quickstart-typescript.md`, mirroring `docs/quickstart.md` step for step: install, record, chain onto a parent, verify, tamper so verification fails, undo so it verifies again. Linked from the README contents list next to the Python entry; both docs cross-link each other from their intros.

## Acceptance criteria

- **Uses `@contextpassport/core` v2.x** — install line pins `^2.0.0`; CI installs the same range.
- **Every code block runs as written** — executed locally against the published 2.0.0 package via tsx; CI re-runs all five blocks on every PR and the weekly cron.
- **Blocks form one coherent script** — single import at the top; the checker concatenates the blocks verbatim and runs them.
- **Roughly the same length** — 108 lines vs the Python doc's 107.
- **Tampering actually fails verification** — the checker asserts the document's exact output contract: passport id (`ctx_…`), payload hash (`sha256:…`), then booleans `true`, `true`, `false`, `true` (parent-hash linkage, verify, verify after tampering, verify after undo), plus a strict six-line total so unexpected output can't slip through.

## CI check (the optional extra from the issue)

`tools/check-quickstart-ts.mjs`, a Node twin of `tools/check-quickstart.py`, wired into the existing `docs-and-examples` job in `.github/workflows/ci.yml`. It extracts the ```typescript fences, runs them as one ESM script via tsx against the real SDK, and asserts the results rather than trusting prose.

## Implementation notes

- Returned passports carry the spec's snake_case JSON fields (`integrity.payload_hash`, `integrity.parent_hash`, `integrity.integrity_hash`) per the published `dist/passport.d.ts`; camelCase is only the `MakePassportInput` surface (`agentId`, `eventType`, …). Cross-checked against the SDK's own test suite and this repo's `schema/v2.json`.
- The extracted script is written as `.mts` inside an in-repo temp dir so ESM resolution finds the repo-installed package regardless of cwd (repo `package.json` is not `"type": "module"`); `.tmp-*/` is gitignored.