### PR TITLE
chore: pin LF line endings for parsed tooling files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.md   text eol=lf
+*.json text eol=lf
+*.mjs  text eol=lf
+*.py   text eol=lf


### PR DESCRIPTION
Closes #39

Adds `.gitattributes` so markdown, JSON, `.mjs`, and `.py` files checkout as LF
on Windows (`core.autocrlf=true`).

Includes `git add --renormalize .` in this commit so existing clones do not
pick up line-ending-only diffs later.

Related: #37 fixes CRLF in the Node reader; this stops the class of problem
at the source for future parsers.

## Test plan
- [x] `node tools/check-quickstart-ts.mjs`
- [x] `python tools/check-quickstart.py`
- [x] `npm test` (no integrity hash changes)