### PR TITLE
examples: add developer event passports and generator (#33)

### DIFF
--- a/examples/branch.json
+++ b/examples/branch.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358470000_b1a2c3d4e5f8",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "alt-pricing",
+  "created_by": {
+    "agent_id": "agent-planner-01",
+    "agent_name": "Planner Agent",
+    "role": "planner",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "branch",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T10:32:00Z"
+  },
+  "payload": {
+    "input": "Fork alternate pricing copy after reviewer checkpoint.",
+    "output": {
+      "action": "created",
+      "from_branch": "main",
+      "branch_key": "alt-pricing",
+      "reason": "Explore alternate enterprise pricing wording."
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:17a4e721b08159c0e7e901ac24929731ee651406c105132fd0ddf0498adbc63c",
+    "parent_hash": null,
+    "integrity_hash": "sha256:d1b22b0c4222148bcfabd8aff5a73ec3a2b77b154943d087a18bb37c01093bf4",
+    "verification_status": "valid"
+  },
+  "created_at": "2026-03-29T10:32:00Z"
+}

--- a/examples/error.json
+++ b/examples/error.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358320000_e1a2b3c4d5e6",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-researcher-01",
+    "agent_name": "Research Agent",
+    "role": "researcher",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "error",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T10:05:00Z"
+  },
+  "payload": {
+    "input": {
+      "tool": "web_search",
+      "arguments": {
+        "query": "Project Atlas enterprise SLA"
+      }
+    },
+    "output": null,
+    "memory": {
+      "error_code": "tool_timeout",
+      "message": "Search provider did not respond within 30 seconds.",
+      "retryable": true
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:713553eb9558b54ce9ec26de197d00de620ff73bf3499ef1b0b4a874eee24cb8",
+    "parent_hash": null,
+    "integrity_hash": "sha256:95cea4ee43f62ee7a614daa091a34751b9b00478cb961e6b4597b602e109d254",
+    "verification_status": "valid"
+  },
+  "created_at": "2026-03-29T10:05:00Z"
+}

--- a/examples/fork.json
+++ b/examples/fork.json
@@ -1,0 +1,79 @@
+[
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358460000_c3d4e5f6a1b2",
+    "parent_id": null,
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-reviewer-01",
+      "agent_name": "Reviewer Agent",
+      "role": "reviewer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "checkpoint",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:31:00Z"
+    },
+    "payload": {
+      "input": {
+        "draft": "Customer-facing launch summary prepared.",
+        "open_questions": [
+          "Confirm enterprise support SLA wording."
+        ]
+      },
+      "output": {
+        "decision": "approved_with_minor_edits",
+        "notes": [
+          "Remove unverifiable adoption metric.",
+          "Keep pricing language source-backed."
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:3eb2fcd7fa14ffc8b7bab54667ffdc68263da2e403ac0ddfe78065adb0f8b34f",
+      "parent_hash": null,
+      "integrity_hash": "sha256:5364f59ce76fd24f8c251000a85ee3d67da710fd9fa46895d1b926a3a8a7d7a1",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:31:00Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358480000_d1e2f3a4b5c6",
+    "parent_id": "ctx_1774358460000_c3d4e5f6a1b2",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "alt-pricing",
+    "created_by": {
+      "agent_id": "agent-planner-01",
+      "agent_name": "Planner Agent",
+      "role": "planner",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "fork",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:33:00Z"
+    },
+    "payload": {
+      "input": "Explore alternate enterprise pricing copy on a side branch.",
+      "output": {
+        "fork_from": "ctx_1774358460000_c3d4e5f6a1b2",
+        "branch_key": "alt-pricing",
+        "reason": "Test softer enterprise pricing language before merge."
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:4a33009be77f1b0f163a8cf59d2a7961172ba4b7280848a5ede393267be60324",
+      "parent_hash": "sha256:5364f59ce76fd24f8c251000a85ee3d67da710fd9fa46895d1b926a3a8a7d7a1",
+      "integrity_hash": "sha256:6894224dc6dcbe421aa73fea808155db22f23f91ed36f8ce2553bf653be1ec53",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:33:00Z"
+  }
+]

--- a/examples/merge.json
+++ b/examples/merge.json
@@ -1,0 +1,110 @@
+[
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358291000_a1b2c3d4e5f6",
+    "parent_id": null,
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-researcher-01",
+      "agent_name": "Research Agent",
+      "role": "researcher",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "commit",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:00:00Z"
+    },
+    "payload": {
+      "input": "Collect public launch notes for Project Atlas.",
+      "output": {
+        "summary": "Found release notes, pricing FAQ, and support article.",
+        "confidence": 0.91,
+        "sources": [
+          "release-notes.md",
+          "pricing-faq.md"
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
+      "parent_hash": null,
+      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:00:00Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358500000_a1b2c3d4e5f6",
+    "parent_id": "ctx_1774358291000_a1b2c3d4e5f6",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "alt-pricing",
+    "created_by": {
+      "agent_id": "agent-writer-01",
+      "agent_name": "Writer Agent",
+      "role": "writer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "commit",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:35:00Z"
+    },
+    "payload": {
+      "input": "Draft alternate enterprise pricing wording on alt-pricing branch.",
+      "output": {
+        "draft": "Enterprise plans include priority support with a published SLA.",
+        "branch_key": "alt-pricing"
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:5668c768bace5b0b95e3ff3ffabd4950033929f710fb4d5beea245df1ed1bc39",
+      "parent_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
+      "integrity_hash": "sha256:c1360cfaedda31143bf0be502f3acb02cfa779767772a1d68c605b89c1bd8a59",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:35:00Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358510000_0a1b2c3d4e5f",
+    "parent_id": "ctx_1774358500000_a1b2c3d4e5f6",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-planner-01",
+      "agent_name": "Planner Agent",
+      "role": "planner",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "merge",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:36:00Z"
+    },
+    "payload": {
+      "input": "Merge alt-pricing wording back onto main after reviewer approval.",
+      "output": {
+        "merged_from": "alt-pricing",
+        "strategy": "take_alt_pricing_wording",
+        "conflicts": 0,
+        "result": "Enterprise SLA wording updated on main."
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:445713597279c490a18da0362b0a1ae4907ea9f891f8fc73e43c61fd8574500c",
+      "parent_hash": "sha256:c1360cfaedda31143bf0be502f3acb02cfa779767772a1d68c605b89c1bd8a59",
+      "integrity_hash": "sha256:258bc5bd7ad87a5181e7db764075a57eade7bbb7b835a1dc3edda53ec2cfdef4",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:36:00Z"
+  }
+]

--- a/examples/retry.json
+++ b/examples/retry.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358355000_c1d2e3f4a5b6",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-researcher-01",
+    "agent_name": "Research Agent",
+    "role": "researcher",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "retry",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T10:08:00Z"
+  },
+  "payload": {
+    "input": {
+      "tool": "web_search",
+      "arguments": {
+        "query": "Project Atlas enterprise SLA"
+      }
+    },
+    "output": null,
+    "memory": {
+      "attempt": 2,
+      "reason": "rate_limit",
+      "backoff_ms": 2000,
+      "previous_error_code": "tool_timeout"
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:af1da6740ef7fe51c2825a256e16f6016e83e2d7538fd191f378f91c868003f1",
+    "parent_hash": null,
+    "integrity_hash": "sha256:d6b096a85574cd6ff18777ccb169c99a38a8dfd3bb286021ae5ccd19ed5cd273",
+    "verification_status": "valid"
+  },
+  "created_at": "2026-03-29T10:08:00Z"
+}

--- a/examples/revert.json
+++ b/examples/revert.json
@@ -1,0 +1,73 @@
+[
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358350000_b2c3d4e5f6a1",
+    "parent_id": null,
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-writer-01",
+      "agent_name": "Writer Agent",
+      "role": "writer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "commit",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:12:30Z"
+    },
+    "payload": {
+      "input": "Draft customer-facing launch summary from research brief.",
+      "output": {
+        "draft": "Customer-facing launch summary prepared.",
+        "open_questions": [
+          "Confirm enterprise support SLA wording."
+        ]
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:60204ae61e367079befcecefb1e2c30e96c5eac0aaf39a1e012225455fb059a8",
+      "parent_hash": null,
+      "integrity_hash": "sha256:282bdc85e3ced5b9b5ac4ddc33d681811918a417bc2b69fce2f23748f47b4976",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:12:30Z"
+  },
+  {
+    "$schema": "https://contextpassport.com/schema/v2.json",
+    "schema_version": "2.0",
+    "id": "ctx_1774358490000_e5f6a7b8c9da",
+    "parent_id": "ctx_1774358350000_b2c3d4e5f6a1",
+    "trace_id": "trace_demo_research_brief",
+    "branch_key": "main",
+    "created_by": {
+      "agent_id": "agent-reviewer-01",
+      "agent_name": "Reviewer Agent",
+      "role": "reviewer",
+      "provider": "example",
+      "model": "demo-agent-v1"
+    },
+    "event": {
+      "type": "revert",
+      "to_agent_id": null,
+      "timestamp": "2026-03-29T10:34:00Z"
+    },
+    "payload": {
+      "input": "Reviewer flagged unverifiable adoption metric in the draft.",
+      "output": {
+        "reverted_record": "ctx_1774358350000_b2c3d4e5f6a1",
+        "reason": "Draft included an adoption metric without a source citation.",
+        "restored_to": "research_brief_only"
+      }
+    },
+    "integrity": {
+      "payload_hash": "sha256:d57d6ac2decd245e4d2757c85a4fc669863101f129faa12789118ea3c9c22ae0",
+      "parent_hash": "sha256:282bdc85e3ced5b9b5ac4ddc33d681811918a417bc2b69fce2f23748f47b4976",
+      "integrity_hash": "sha256:da1f660badc3692c0e97123d389764f14eced93c8fcc2e998f0536bc875edcd9",
+      "verification_status": "valid"
+    },
+    "created_at": "2026-03-29T10:34:00Z"
+  }
+]

--- a/examples/spawn.json
+++ b/examples/spawn.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358330000_a1b2c3d4e5f7",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-planner-01",
+    "agent_name": "Planner Agent",
+    "role": "planner",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "spawn",
+    "to_agent_id": "agent-writer-01",
+    "timestamp": "2026-03-29T10:06:00Z"
+  },
+  "payload": {
+    "input": {
+      "summary": "Found release notes, pricing FAQ, and support article.",
+      "confidence": 0.91,
+      "sources": [
+        "release-notes.md",
+        "pricing-faq.md"
+      ]
+    },
+    "output": {
+      "handoff": "Write a customer-facing launch summary from the research brief."
+    },
+    "variables": {
+      "tone": "customer_facing",
+      "max_words": 600
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:d94802bf53799d6617a0f2712ea555ce74d709f836617483c1d5510947c1b501",
+    "parent_hash": null,
+    "integrity_hash": "sha256:815f92fdc28ed28981b798476c8d76b0618b82380ae294b51227bdb8e0477d9c",
+    "verification_status": "valid"
+  },
+  "created_at": "2026-03-29T10:06:00Z"
+}

--- a/examples/timeout.json
+++ b/examples/timeout.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://contextpassport.com/schema/v2.json",
+  "schema_version": "2.0",
+  "id": "ctx_1774358340000_f1e2d3c4b5a6",
+  "parent_id": null,
+  "trace_id": "trace_demo_research_brief",
+  "branch_key": "main",
+  "created_by": {
+    "agent_id": "agent-researcher-01",
+    "agent_name": "Research Agent",
+    "role": "researcher",
+    "provider": "example",
+    "model": "demo-agent-v1"
+  },
+  "event": {
+    "type": "timeout",
+    "to_agent_id": null,
+    "timestamp": "2026-03-29T10:07:00Z"
+  },
+  "payload": {
+    "input": {
+      "tool": "web_search",
+      "arguments": {
+        "query": "Project Atlas enterprise SLA"
+      }
+    },
+    "output": null,
+    "memory": {
+      "operation": "tool_call:web_search",
+      "timeout_ms": 30000,
+      "elapsed_ms": 30001
+    }
+  },
+  "integrity": {
+    "payload_hash": "sha256:27638e9a50676792faec8ac240374e5ce1789d25a2846a10fc87e3622abb3689",
+    "parent_hash": null,
+    "integrity_hash": "sha256:79f87b18d7f2f5537d9554e9099b9521a0ee77ad83cf9a914877cb68b44483a1",
+    "verification_status": "valid"
+  },
+  "created_at": "2026-03-29T10:07:00Z"
+}

--- a/tools/generate-developer-examples.py
+++ b/tools/generate-developer-examples.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+Generates developer-event examples in examples/ using the Python reference SDK,
+so the integrity hashes are real rather than hand-written.
+
+    pip install context-passport
+    python tools/generate-developer-examples.py
+
+Identifiers and timestamps are pinned to fixed, readable values. That is safe:
+under SPEC.md 3.4 the integrity block covers the payload and the parent hash
+only. Pinning keeps the files stable in review and in git history.
+
+Run `npm test` after regenerating to validate against schema/v2.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from context_passport import make_passport
+
+ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = ROOT / "examples"
+
+DROP = ("lineage",)
+
+TRACE = "trace_demo_research_brief"
+PROVIDER = "example"
+MODEL = "demo-agent-v1"
+
+
+def build(
+    payload,
+    *,
+    agent_id,
+    agent_name,
+    event_type,
+    role=None,
+    provider=PROVIDER,
+    model=MODEL,
+    trace_id=TRACE,
+    parent=None,
+    branch_key="main",
+    to_agent_id=None,
+):
+    p = make_passport(
+        agent_id=agent_id,
+        agent_name=agent_name,
+        payload=payload,
+        parent=parent,
+        to_agent_id=to_agent_id,
+        role=role,
+        provider=provider,
+        model=model,
+        event_type=event_type,
+        trace_id=trace_id,
+        branch_key=branch_key,
+    )
+    for key in DROP:
+        p.pop(key, None)
+    return p
+
+
+def pin(passport, *, ctx_id, timestamp):
+    """Fix the identifiers and timestamps. Hashes are unaffected."""
+    passport["id"] = ctx_id
+    passport["created_at"] = timestamp
+    passport["event"]["timestamp"] = timestamp
+    if passport["integrity"].get("verified_at") is not None:
+        passport["integrity"]["verified_at"] = timestamp
+    return passport
+
+
+def relink(child, parent):
+    """Point a pinned child at its pinned parent."""
+    child["parent_id"] = parent["id"]
+    return child
+
+
+def write(name, data):
+    path = EXAMPLES / name
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"  wrote examples/{name}")
+
+
+# ------------------------------------------------------------------- error
+
+error = pin(
+    build(
+        {
+            "input": {
+                "tool": "web_search",
+                "arguments": {"query": "Project Atlas enterprise SLA"},
+            },
+            "output": None,
+            "memory": {
+                "error_code": "tool_timeout",
+                "message": "Search provider did not respond within 30 seconds.",
+                "retryable": True,
+            },
+        },
+        agent_id="agent-researcher-01",
+        agent_name="Research Agent",
+        event_type="error",
+        role="researcher",
+    ),
+    ctx_id="ctx_1774358320000_e1a2b3c4d5e6",
+    timestamp="2026-03-29T10:05:00Z",
+)
+write("error.json", error)
+
+
+# ------------------------------------------------------------------- spawn
+
+spawn = pin(
+    build(
+        {
+            "input": {
+                "summary": "Found release notes, pricing FAQ, and support article.",
+                "confidence": 0.91,
+                "sources": ["release-notes.md", "pricing-faq.md"],
+            },
+            "output": {
+                "handoff": "Write a customer-facing launch summary from the research brief.",
+            },
+            "variables": {
+                "tone": "customer_facing",
+                "max_words": 600,
+            },
+        },
+        agent_id="agent-planner-01",
+        agent_name="Planner Agent",
+        event_type="spawn",
+        role="planner",
+        to_agent_id="agent-writer-01",
+    ),
+    ctx_id="ctx_1774358330000_a1b2c3d4e5f7",
+    timestamp="2026-03-29T10:06:00Z",
+)
+write("spawn.json", spawn)
+
+
+# ----------------------------------------------------------------- timeout
+
+timeout = pin(
+    build(
+        {
+            "input": {
+                "tool": "web_search",
+                "arguments": {"query": "Project Atlas enterprise SLA"},
+            },
+            "output": None,
+            "memory": {
+                "operation": "tool_call:web_search",
+                "timeout_ms": 30000,
+                "elapsed_ms": 30001,
+            },
+        },
+        agent_id="agent-researcher-01",
+        agent_name="Research Agent",
+        event_type="timeout",
+        role="researcher",
+    ),
+    ctx_id="ctx_1774358340000_f1e2d3c4b5a6",
+    timestamp="2026-03-29T10:07:00Z",
+)
+write("timeout.json", timeout)
+
+
+# ------------------------------------------------------------------ branch
+
+branch = pin(
+    build(
+        {
+            "input": "Fork alternate pricing copy after reviewer checkpoint.",
+            "output": {
+                "action": "created",
+                "from_branch": "main",
+                "branch_key": "alt-pricing",
+                "reason": "Explore alternate enterprise pricing wording.",
+            },
+        },
+        agent_id="agent-planner-01",
+        agent_name="Planner Agent",
+        event_type="branch",
+        role="planner",
+        branch_key="alt-pricing",
+    ),
+    ctx_id="ctx_1774358470000_b1a2c3d4e5f8",
+    timestamp="2026-03-29T10:32:00Z",
+)
+write("branch.json", branch)
+
+
+# ------------------------------------------------------------------- retry
+
+retry = pin(
+    build(
+        {
+            "input": {
+                "tool": "web_search",
+                "arguments": {"query": "Project Atlas enterprise SLA"},
+            },
+            "output": None,
+            "memory": {
+                "attempt": 2,
+                "reason": "rate_limit",
+                "backoff_ms": 2000,
+                "previous_error_code": "tool_timeout",
+            },
+        },
+        agent_id="agent-researcher-01",
+        agent_name="Research Agent",
+        event_type="retry",
+        role="researcher",
+    ),
+    ctx_id="ctx_1774358355000_c1d2e3f4a5b6",
+    timestamp="2026-03-29T10:08:00Z",
+)
+write("retry.json", retry)
+
+
+# ------------------------------------------------------------------- fork
+# A fork only means something next to the checkpoint it branches from.
+
+fork_checkpoint = pin(
+    build(
+        {
+            "input": {
+                "draft": "Customer-facing launch summary prepared.",
+                "open_questions": ["Confirm enterprise support SLA wording."],
+            },
+            "output": {
+                "decision": "approved_with_minor_edits",
+                "notes": [
+                    "Remove unverifiable adoption metric.",
+                    "Keep pricing language source-backed.",
+                ],
+            },
+        },
+        agent_id="agent-reviewer-01",
+        agent_name="Reviewer Agent",
+        event_type="checkpoint",
+        role="reviewer",
+    ),
+    ctx_id="ctx_1774358460000_c3d4e5f6a1b2",
+    timestamp="2026-03-29T10:31:00Z",
+)
+
+fork_event = pin(
+    build(
+        {
+            "input": "Explore alternate enterprise pricing copy on a side branch.",
+            "output": {
+                "fork_from": "ctx_1774358460000_c3d4e5f6a1b2",
+                "branch_key": "alt-pricing",
+                "reason": "Test softer enterprise pricing language before merge.",
+            },
+        },
+        agent_id="agent-planner-01",
+        agent_name="Planner Agent",
+        event_type="fork",
+        role="planner",
+        branch_key="alt-pricing",
+        parent=fork_checkpoint,
+    ),
+    ctx_id="ctx_1774358480000_d1e2f3a4b5c6",
+    timestamp="2026-03-29T10:33:00Z",
+)
+relink(fork_event, fork_checkpoint)
+write("fork.json", [fork_checkpoint, fork_event])
+
+
+# ----------------------------------------------------------------- revert
+
+revert_commit = pin(
+    build(
+        {
+            "input": "Draft customer-facing launch summary from research brief.",
+            "output": {
+                "draft": "Customer-facing launch summary prepared.",
+                "open_questions": ["Confirm enterprise support SLA wording."],
+            },
+        },
+        agent_id="agent-writer-01",
+        agent_name="Writer Agent",
+        event_type="commit",
+        role="writer",
+    ),
+    ctx_id="ctx_1774358350000_b2c3d4e5f6a1",
+    timestamp="2026-03-29T10:12:30Z",
+)
+
+revert_event = pin(
+    build(
+        {
+            "input": "Reviewer flagged unverifiable adoption metric in the draft.",
+            "output": {
+                "reverted_record": "ctx_1774358350000_b2c3d4e5f6a1",
+                "reason": "Draft included an adoption metric without a source citation.",
+                "restored_to": "research_brief_only",
+            },
+        },
+        agent_id="agent-reviewer-01",
+        agent_name="Reviewer Agent",
+        event_type="revert",
+        role="reviewer",
+        parent=revert_commit,
+    ),
+    ctx_id="ctx_1774358490000_e5f6a7b8c9da",
+    timestamp="2026-03-29T10:34:00Z",
+)
+relink(revert_event, revert_commit)
+write("revert.json", [revert_commit, revert_event])
+
+
+# ------------------------------------------------------------------ merge
+
+merge_ancestor = pin(
+    build(
+        {
+            "input": "Collect public launch notes for Project Atlas.",
+            "output": {
+                "summary": "Found release notes, pricing FAQ, and support article.",
+                "confidence": 0.91,
+                "sources": ["release-notes.md", "pricing-faq.md"],
+            },
+        },
+        agent_id="agent-researcher-01",
+        agent_name="Research Agent",
+        event_type="commit",
+        role="researcher",
+    ),
+    ctx_id="ctx_1774358291000_a1b2c3d4e5f6",
+    timestamp="2026-03-29T10:00:00Z",
+)
+
+merge_branch_work = pin(
+    build(
+        {
+            "input": "Draft alternate enterprise pricing wording on alt-pricing branch.",
+            "output": {
+                "draft": "Enterprise plans include priority support with a published SLA.",
+                "branch_key": "alt-pricing",
+            },
+        },
+        agent_id="agent-writer-01",
+        agent_name="Writer Agent",
+        event_type="commit",
+        role="writer",
+        branch_key="alt-pricing",
+        parent=merge_ancestor,
+    ),
+    ctx_id="ctx_1774358500000_a1b2c3d4e5f6",
+    timestamp="2026-03-29T10:35:00Z",
+)
+relink(merge_branch_work, merge_ancestor)
+
+merge_event = pin(
+    build(
+        {
+            "input": "Merge alt-pricing wording back onto main after reviewer approval.",
+            "output": {
+                "merged_from": "alt-pricing",
+                "strategy": "take_alt_pricing_wording",
+                "conflicts": 0,
+                "result": "Enterprise SLA wording updated on main.",
+            },
+        },
+        agent_id="agent-planner-01",
+        agent_name="Planner Agent",
+        event_type="merge",
+        role="planner",
+        parent=merge_branch_work,
+    ),
+    ctx_id="ctx_1774358510000_0a1b2c3d4e5f",
+    timestamp="2026-03-29T10:36:00Z",
+)
+relink(merge_event, merge_branch_work)
+write("merge.json", [merge_ancestor, merge_branch_work, merge_event])
+
+print("\nRun `npm test` to validate these against schema/v2.json.")


### PR DESCRIPTION
Closes #33

## Summary

Add example passport JSON for the eight missing developer event types, each valid against `schema/v2.json` with SDK-generated integrity hashes (not hand-written).

- **Single records:** `error.json`, `spawn.json`, `timeout.json`, `branch.json`, `retry.json`
- **Linear chains:** `fork.json` (checkpoint → fork), `revert.json` (commit → revert), `merge.json` (commit → branch commit → merge)
- **Generator:** `tools/generate-developer-examples.py` — mirrors `tools/generate-compliance-examples.py` (`make_passport` → strip `lineage` → pin ids/timestamps → `relink` chains → write to `examples/`)

All records include `trace_id` and `branch_key`; hashes are recomputed from payload + parent per SPEC §3.4.

## Test plan

- [x] `pip install context-passport`
- [x] `python tools/generate-developer-examples.py`
- [x] `npm test` — all 17 example files pass schema validation, hash recompute, and chain linkage checks