### PR TITLE
Align §2.6 custom event-type namespacing with §3.3's SHOULD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ are unaffected.
   by dots (#35). Not breaking under this file's definition — no hashed bytes
   change and every specified type matches — but records from implementations
   that ignored the naming guidance may now fail schema validation.
+- §2.6 now says custom event types SHOULD be prefixed with a namespace, matching
+  §3.3's keyword and mechanism language, instead of requiring that new event
+  types MUST be namespaced. The fifteen specified types remain conforming
+  without a namespace; custom fields and vendor extensions stay MUST (#38). Not
+  breaking under this file's definition — no hashed bytes change and no
+  previously conforming record becomes non-conforming.
 
 ## [2.0] - 2026-05-19
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -82,7 +82,7 @@ This specification is released under CC0 1.0 — no copyright, no restrictions. 
 
 ### 2.6 Forward-compatible by extension
 
-The specification grows by addition, never by breaking change within a major version. New event types, custom fields, and vendor-specific extensions MUST be namespaced (e.g. `myorg.custom_type`, `myorg.field_name`). Implementations MUST ignore unknown namespaced fields without error. A formal extension registry lives at `EXTENSIONS.md` in the repository. Anyone may submit an extension via pull request; widely-adopted extensions are candidates for promotion to the core spec in subsequent major versions.
+The specification grows by addition, never by breaking change within a major version. Custom event types SHOULD be prefixed with a namespace (e.g. `myorg.custom_type`). Custom fields and vendor-specific extensions MUST be namespaced (e.g. `myorg.field_name`). Implementations MUST ignore unknown namespaced fields without error. A formal extension registry lives at `EXTENSIONS.md` in the repository. Anyone may submit an extension via pull request; widely-adopted extensions are candidates for promotion to the core spec in subsequent major versions.
 
 ---
 


### PR DESCRIPTION
## Summary
- Aligns §2.6 with §3.3: custom event types SHOULD be prefixed with a namespace (was an overbroad MUST on “new event types”).
- Splits the clauses so custom fields / vendor extensions stay MUST namespaced; the fifteen specified types remain conforming without a namespace.
- Records the change in CHANGELOG.md as not compatibility-affecting. No schema/v2.json change.

Fixes #38.

## Test plan
- [x] Confirm §2.6 and §3.3 use the same RFC 2119 keyword (SHOULD) for custom event-type namespacing
- [x] Confirm specified types (commit, audit, merge, …) still read as conforming without a namespace
- [x] Confirm CHANGELOG states the change is not breaking under that file’s definition
- [x] Grep SPEC.md for any third conflicting paraphrase of the rule