### PR TITLE
governance: make the substantive-change threshold satisfiable at this size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ are unaffected.
   without a namespace; custom fields and vendor extensions stay MUST (#38). Not
   breaking under this file's definition — no hashed bytes change and no
   previously conforming record becomes non-conforming.
+- `GOVERNANCE.md`: the two-maintainer approval threshold for substantive changes
+  is now satisfiable while the project has fewer than two maintainers, by
+  approval from every listed maintainer plus the full 14-day RFC window. As
+  written, that threshold made every substantive change unmergeable by anyone,
+  including the sole maintainer. The accommodation lapses automatically once a
+  second maintainer is listed in `.github/CODEOWNERS`. The same section now
+  states that reconciling a contradiction between two sections is editorial
+  where no conforming implementation changes behaviour.
 
 ## [2.0] - 2026-05-19
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,9 +22,11 @@ The current list of maintainers is published in the `.github/CODEOWNERS` file of
 
 ## Decision-making
 
-**Editorial changes** (typos, clarifications, examples that do not change behavior): any maintainer may merge.
+**Editorial changes** (typos, clarifications, examples that do not change behavior): any maintainer may merge. A change that reconciles a contradiction between two sections is editorial when it leaves the behavior of every conforming implementation unchanged, even where the wording it corrects was normative.
 
 **Substantive changes** (new fields, changed semantics, new event types in the core spec): require a public RFC issue open for at least 14 days, with explicit approval from at least two maintainers and no unresolved objections from any maintainer.
+
+While fewer than two maintainers are listed in `.github/CODEOWNERS`, approval from every listed maintainer satisfies the approval threshold, provided the full 14-day RFC window has elapsed. The window is not waivable and is what substitutes for a second reviewer: it is the period in which anyone at all may object in public. This accommodation lapses automatically as soon as a second maintainer is listed, and it exists to keep the specification amendable at the project's current size rather than to lower the bar permanently.
 
 **Breaking changes** (changes that would invalidate prior-major-version-conformant passports): not permitted within a major version. Breaking changes ship in a new major version with a documented migration path and a per-version verification shim in the reference implementations (see [`docs/migrations/v1-to-v2.md`](docs/migrations/v1-to-v2.md) for the v1.x → v2.0 worked example).
 


### PR DESCRIPTION
## The problem

`GOVERNANCE.md` requires substantive changes to have "explicit approval from at least two maintainers". `.github/CODEOWNERS` lists one.

So every substantive change to this specification is currently unmergeable by anyone, including the sole maintainer. Not difficult, not discouraged: arithmetically impossible.

This surfaced in #42, which was the first normative change ever sent here by an outside contributor. It got merged as editorial, and I think that ruling is right, but it should not be the only route through a document that intends to have two.

## What this changes

**1. The threshold becomes satisfiable, and repairs itself.**

While fewer than two maintainers are listed in `CODEOWNERS`, approval from every listed maintainer satisfies the approval requirement, provided the full 14-day RFC window has elapsed.

The window is deliberately not waivable. It is what substitutes for the second reviewer: the period in which anyone at all, maintainer or not, may object in public. Dropping both the second approver and the waiting period would be lowering the bar. Keeping the window and scaling the approver count to the project's actual size is not.

The accommodation lapses automatically the moment a second maintainer is listed. Nobody has to remember to remove it.

**2. The editorial test from #42 is written down.**

A change that reconciles a contradiction between two sections is editorial when it leaves the behaviour of every conforming implementation unchanged, even where the wording it corrects was normative.

That is the reasoning I applied to #42 and it should not have to be re-derived by the next person. It also has a real limit: it covers reconciling contradictions, not relaxing requirements the document actually meant.

## What this does not change

- The 14-day RFC window, for any substantive change, at any project size
- "No unresolved objections from any maintainer"
- The definition of breaking changes, which remain barred within a major version
- Anything about the wire format. No hashed bytes move

## Note on process

`GOVERNANCE.md` is on the list of files I do not merge without you, so this is opened for your decision rather than pushed. It is also, by its own terms, the kind of document that should change through a pull request rather than a direct push, which is the other reason it is here.

Worth deciding explicitly: this amendment is itself arguably substantive, and `GOVERNANCE.md` says it "is itself subject to change via the RFC process". If you want that followed to the letter, this should sit behind an `rfc` issue for 14 days. My view is that a clause which cannot be satisfied by anyone is a defect rather than a policy, and fixing a defect that blocks the amendment process should not be gated behind the process it blocks. But that is a judgement call and it is yours.
