### PR TITLE
chore: acknowledge the fifth fork, which is not an adoption signal

### DIFF
--- a/.github/adoption.json
+++ b/.github/adoption.json
@@ -4,7 +4,7 @@
     "python": 0,
     "typescript": 0,
     "mcp": 0,
-    "forks": 4,
+    "forks": 5,
     "stars": 0
   }
 }


### PR DESCRIPTION
Forks went from 4 to 5 on 24 August. The steward workflow compares against `.github/adoption.json` and nags weekly until a human commits the new numbers, so Monday's run would have reported this as adoption.

It is not adoption. The fifth fork is @Muzammil327, who forked in order to open #36, #37, #40, #41 and #42. A contributor forking to send us pull requests is the opposite of an outside party picking up the format.

Acknowledging it at 5 so the alert stays trustworthy. Every other signal stays at zero, which is still the honest number.

```
2026-08-24  Muzammil327          pushed:2026-08-27
2026-08-14  MikeGatsby           pushed:2026-06-12
2026-05-27  choucaleb602-commits pushed:2026-06-12
2026-05-19  zhouzhou626          pushed:2026-05-19
2026-05-18  Bhavesh-0409         pushed:2026-05-18
```