### PR TITLE
chore: pin LF line endings for .js and .yml files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 *.md   text eol=lf
 *.json text eol=lf
 *.mjs  text eol=lf
+*.js   text eol=lf
 *.py   text eol=lf
+*.yml  text eol=lf


### PR DESCRIPTION
## Summary
- Extend `.gitattributes` so `*.js` and `*.yml` are pinned to LF, matching #40's coverage for `.md` / `.json` / `.mjs` / `.py`.
- Closes the remaining gap from #39: prevent the next line-ending parser breakage rather than wait for another Windows checkout bug.
- Fixes #45. Background: #39, #37 / #40.

## Note for reviewers
Updating `.gitattributes` does not rewrite an existing working tree. Git only renormalizes when file content changes between commits, so old clones may still show CRLF until a forced re-checkout (e.g. `git add --renormalize .`) or a fresh clone. New clones get LF immediately.

## Test plan
- [x] `node tools/check-quickstart-ts.mjs`
- [x] `python tools/check-quickstart.py`
- [x] `npm test` — all 17 examples valid; recomputed hashes unchanged