### PR TITLE
Stop two documents claiming more than the spec supports

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -5,9 +5,12 @@ Extensions allow implementations to add new event types and new fields without m
 ## How extensions work
 
 1. Pick a namespace prefix unique to your organization. Examples: `acme`, `bankco`, `fintechco`.
-2. Use that prefix on every custom event type or field name: `acme.payment_authorized`, `bankco.kyc_event`, `fintechco.position_opened`.
-3. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
-4. Register the extension in this file via pull request so other implementers can discover and reuse it.
+2. Use that prefix on every custom field name and vendor extension: `bankco.kyc_reference`, `fintechco.position_id`. This is a MUST, and it is what makes rule 3 possible.
+3. Custom **event types** SHOULD carry the prefix too: `acme.payment_authorized`, `bankco.kyc_event`. It is a SHOULD rather than a MUST because an unrecognised event type is
+   already safe to skip, whereas an unrecognised bare field could collide with a core field
+   added in a later version. Event types must in all cases match the pattern in SPEC.md 3.3.
+4. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
+5. Register the extension in this file via pull request so other implementers can discover and reuse it.
 
 ## Promotion to core
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -27,6 +27,9 @@ See [`contextpassport/conformance-tests`](https://github.com/contextpassport/con
 - **Core** — passes `vectors/required/`. Produces and verifies plain (unsigned) passports correctly.
 - **Signed** — Core plus `vectors/signed/`. Produces and verifies Ed25519-signed passports.
 - **Full** — Signed plus `vectors/recommended/`. Handles fork lineage, extensions, and long chains.
+  **Not currently claimable:** no recommended vectors are published yet, and the conformance
+  harness exits 1 on `--level full` rather than reporting a pass nobody has earned. Listed here
+  because it defines the target, not because any implementation can reach it today.
 
 An implementation is **Context Passport v2.0 Core conformant** if it:
 


### PR DESCRIPTION
Closes #46. Closes #44.

### #46 EXTENSIONS.md overstated the namespacing rule

Rule 2 read:

> Use that prefix on every custom event type or field name

One imperative covering both. SPEC.md 2.6 distinguishes them: custom fields and vendor extensions **MUST** be namespaced, custom event types **SHOULD** be. The rules are now split, and the reason is stated rather than left implicit.

An unrecognised event type is already safe to skip, so a namespace is good practice rather than a safety requirement. An unrecognised bare field is different: it could collide with a core field added in a later version, which is what the MUST protects against.

A registry that states a rule more strongly than the specification is a registry implementers learn to read loosely.

### #44 IMPLEMENTATIONS.md advertised a level nobody can claim

Full sat beside Core and Signed as though all three were available. The conformance harness says otherwise:

> (No recommended vectors are published yet, `--level full` currently exits 1 to prevent silent green-ticking.)

The harness is being careful not to hand out a pass nobody earned. The canonical document was undoing that care. Full stays listed, because it defines the target, now marked explicitly as not currently claimable.

### #45

Already fixed by #49; `.gitattributes` covers `*.js` and `*.yml`. The issue outlived the work and is now closed.

`npm test` passes: examples validate against the schema with recomputed hashes.