### PR TITLE
List the two DarkMatter implementations as ordinary rows

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -5,9 +5,12 @@ Extensions allow implementations to add new event types and new fields without m
 ## How extensions work
 
 1. Pick a namespace prefix unique to your organization. Examples: `acme`, `bankco`, `fintechco`.
-2. Use that prefix on every custom event type or field name: `acme.payment_authorized`, `bankco.kyc_event`, `fintechco.position_opened`.
-3. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
-4. Register the extension in this file via pull request so other implementers can discover and reuse it.
+2. Use that prefix on every custom field name and vendor extension: `bankco.kyc_reference`, `fintechco.position_id`. This is a MUST, and it is what makes rule 3 possible.
+3. Custom **event types** SHOULD carry the prefix too: `acme.payment_authorized`, `bankco.kyc_event`. It is a SHOULD rather than a MUST because an unrecognised event type is
+   already safe to skip, whereas an unrecognised bare field could collide with a core field
+   added in a later version. Event types must in all cases match the pattern in SPEC.md 3.3.
+4. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
+5. Register the extension in this file via pull request so other implementers can discover and reuse it.
 
 ## Promotion to core
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -10,6 +10,8 @@ To add your implementation: open a pull request editing this file.
 |---|---|---|---|---|---|
 | `contextpassport/python` | Python | Apache-2.0 | github.com/contextpassport/python | v2.0 Core, Signed | Pure-Python, no required dependencies. Optional Ed25519 signing and LangGraph integration. v1.x records verifiable via `context_passport.compat.v1`. |
 | `contextpassport/typescript` | TypeScript | Apache-2.0 | github.com/contextpassport/typescript | v2.0 Core, Signed | TypeScript reference, ESM, no runtime dependencies. Ed25519 signing via Node `crypto`. v1.x records verifiable via `@contextpassport/core/compat/v1`. |
+| `@darkmatterhub/mcp-server` | TypeScript | Apache-2.0 | github.com/darkmatter-hub/mcp | v2.0 Core | MCP server emitting passports for AI agent tool calls. Uses `@contextpassport/core` directly rather than reimplementing the format. |
+| DarkMatter | JavaScript | Proprietary | darkmatterhub.ai | v2.0 Core | Hosted service. Passes the six `vectors/required/` vectors via its own runner over the published CC0 vectors. Signed is **not** claimed: it signs a proprietary L2/L3 envelope binding agent and key identity, not the envelope defined in SPEC.md 3.5. |
 
 ## Third-party implementations
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -27,6 +27,9 @@ See [`contextpassport/conformance-tests`](https://github.com/contextpassport/con
 - **Core** — passes `vectors/required/`. Produces and verifies plain (unsigned) passports correctly.
 - **Signed** — Core plus `vectors/signed/`. Produces and verifies Ed25519-signed passports.
 - **Full** — Signed plus `vectors/recommended/`. Handles fork lineage, extensions, and long chains.
+  **Not currently claimable:** no recommended vectors are published yet, and the conformance
+  harness exits 1 on `--level full` rather than reporting a pass nobody has earned. Listed here
+  because it defines the target, not because any implementation can reach it today.
 
 An implementation is **Context Passport v2.0 Core conformant** if it:
 


### PR DESCRIPTION
IMPLEMENTATIONS.md listed only the two reference SDKs. Two other implementations exist and were absent.

Listing them is the more neutral choice. A standard whose maintainer runs implementations it does not disclose reads worse than one that lists them plainly, and a reader currently cannot tell how many independent implementations exist.

Both appear on the same terms as anything else, at the level each has earned.

**`@darkmatterhub/mcp-server`** — Apache-2.0, uses `@contextpassport/core` directly rather than reimplementing the format.

**DarkMatter** — proprietary, and labelled so. Claims Core, having passed all six `vectors/required/` vectors. Its runner is its own because the reference harness is Python and DarkMatter is JavaScript; it reads these CC0 vectors byte for byte and applies the same `expected` values.

It does **not** claim Signed. The three signature vectors verify against the envelope in SPEC.md 3.5; DarkMatter signs a proprietary L2/L3 envelope binding agent and key identity, which is a different structure. That is a real gap and is recorded as one.

Worth stating explicitly: neither implementation gets a privileged path. Sharing a maintainer buys no conformance level. DarkMatter earned Core in the same week it stopped producing records that failed `verify_chain` in the reference SDKs, and it earned it by implementing the parser required by `v05_schema_version` rather than by skipping that vector.