### PR TITLE
Add a file naming convention, and correct the IANA section

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -5,9 +5,12 @@ Extensions allow implementations to add new event types and new fields without m
 ## How extensions work
 
 1. Pick a namespace prefix unique to your organization. Examples: `acme`, `bankco`, `fintechco`.
-2. Use that prefix on every custom event type or field name: `acme.payment_authorized`, `bankco.kyc_event`, `fintechco.position_opened`.
-3. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
-4. Register the extension in this file via pull request so other implementers can discover and reuse it.
+2. Use that prefix on every custom field name and vendor extension: `bankco.kyc_reference`, `fintechco.position_id`. This is a MUST, and it is what makes rule 3 possible.
+3. Custom **event types** SHOULD carry the prefix too: `acme.payment_authorized`, `bankco.kyc_event`. It is a SHOULD rather than a MUST because an unrecognised event type is
+   already safe to skip, whereas an unrecognised bare field could collide with a core field
+   added in a later version. Event types must in all cases match the pattern in SPEC.md 3.3.
+4. Implementations that do not recognize the namespace MUST ignore the field or event without error. This is required for forward compatibility.
+5. Register the extension in this file via pull request so other implementers can discover and reuse it.
 
 ## Promotion to core
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -27,6 +27,9 @@ See [`contextpassport/conformance-tests`](https://github.com/contextpassport/con
 - **Core** — passes `vectors/required/`. Produces and verifies plain (unsigned) passports correctly.
 - **Signed** — Core plus `vectors/signed/`. Produces and verifies Ed25519-signed passports.
 - **Full** — Signed plus `vectors/recommended/`. Handles fork lineage, extensions, and long chains.
+  **Not currently claimable:** no recommended vectors are published yet, and the conformance
+  harness exits 1 on `--level full` rather than reporting a pass nobody has earned. Listed here
+  because it defines the target, not because any implementation can reach it today.
 
 An implementation is **Context Passport v2.0 Core conformant** if it:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,7 @@ The goal of this specification is to become the standard interchange format for 
       - [Signature (optional)](#327-signature-optional)
    - [Event types](#33-event-types)
    - [Integrity computation](#34-integrity-computation)
+   - [File naming (non-normative)](#35-file-naming-non-normative)
 4. [Conformance](#4-conformance)
 5. [Security considerations](#5-security-considerations)
 6. [IANA considerations](#6-iana-considerations)
@@ -290,6 +291,32 @@ If any comparison fails, the chain is `broken` at that point.
 
 ---
 
+### 3.5 File naming (non-normative)
+
+Nothing in this specification requires a passport to be stored in a file at
+all. Section 2.2 holds: a passport is a JSON value, and a system that keeps
+records in a database, a message queue or a log stream is fully conformant
+without ever writing one to disk.
+
+Where records **are** written to files, implementations SHOULD use:
+
+| Contents | Name |
+|---|---|
+| A single passport | `<name>.passport.json` |
+| An array of passports forming a chain | `<name>.passports.json` |
+
+This exists so that editor tooling can recognise a passport without being
+configured to. A schema catalogue entry matching `*.passport.json` gives
+validation and completion in editors that consult it, with no setup by the
+person writing the file. A convention no more specific than `*.json` cannot do
+that, and one specific to a single vendor's tool would not deserve to.
+
+It is a SHOULD and carries no weight in verification. A file named anything at
+all, or nothing at all, verifies identically: the hashes cover the payload and
+the parent, never the filename.
+
+---
+
 ## 4. Conformance
 
 An implementation is **Context Passport v2.0 conformant** if it:
@@ -341,7 +368,23 @@ See `docs/throughput-and-trust.md` for the full taxonomy and recommended SDK pat
 
 ## 6. IANA considerations
 
-This specification does not require any IANA actions.
+A media type registration is intended in the **vendor tree**:
+
+    application/vnd.contextpassport+json
+
+The vendor tree is the correct tree while this specification is published only
+here. The standards tree (`application/contextpassport+json`) requires a
+permanent specification of the kind RFC 6838 describes, and claiming it without
+one would misrepresent the specification's standing.
+
+The `+json` structured syntax suffix is already registered; this registration
+adds no new suffix. Registration is a matter of discoverability and of settling
+whether the format is real for anyone reviewing it. It confers nothing on
+implementations and changes nothing in sections 3 or 4: a conformant
+implementation is conformant whether or not the media type is ever used.
+
+Until the registration completes, `application/json` remains correct for
+transporting passports.
 
 ---
 


### PR DESCRIPTION
Two small additions, both prompted by trying to put the format in front of people who did not go looking for it.

### 3.5 File naming (non-normative)

Editor tooling can only recognise a passport if the filename says so. Schema catalogues match on filename patterns and explicitly reject generic ones, so `*.json` buys nothing.

There is no convention at all today. The examples here are `audit.json`, `consent.json`, `signed.json` — nothing a catalogue can match without claiming every JSON file in existence.

`*.passport.json` (one) and `*.passports.json` (a chain) are specific enough to match and belong to no vendor.

Deliberately weak: it is a SHOULD, marked non-normative, and §2.2 still holds. A system that keeps records in a database, a queue or a log stream and never writes a file is fully conformant. The hashes cover the payload and the parent, never the filename, so a file called anything at all verifies identically.

### §6 IANA considerations

It said "This specification does not require any IANA actions." A vendor-tree media type registration is intended, so it now says what is intended and why that tree:

    application/vnd.contextpassport+json

The standards tree (`application/contextpassport+json`) requires a permanent specification of the kind RFC 6838 describes. Claiming it without one would misrepresent where this document stands.

The registration confers nothing on implementations and changes nothing in §3 or §4. `application/json` stays correct until it completes.

`npm test` passes.