### PR TITLE
Add .zenodo.json so a release mints a well-formed DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,37 @@
+{
+  "title": "Context Passport: An Open Standard for Structured, Verifiable Records of AI Agent Events",
+  "description": "<p>Context Passport defines a minimal JSON envelope for structured, verifiable records of AI agent events.</p><p>Each record carries the input an agent was given, the output it produced, and an integrity block containing SHA-256 hashes computed over the RFC 8785 (JCS) canonical form of the payload. Records chain by hash, so altering any record breaks verification of every record after it. Verification requires only the records themselves: no server, no account, and no trust in whoever produced them.</p><p>The specification is CC0. Reference implementations in Python and TypeScript are Apache-2.0, and a conformance suite with CC0 test vectors decides whether an implementation conforms.</p>",
+  "upload_type": "publication",
+  "publication_type": "technicalnote",
+  "license": "cc-zero",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Context Passport maintainers"
+    }
+  ],
+  "keywords": [
+    "AI agents",
+    "audit trail",
+    "provenance",
+    "tamper evidence",
+    "hash chain",
+    "RFC 8785",
+    "canonical JSON",
+    "AI governance",
+    "EU AI Act",
+    "interoperability"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/contextpassport/spec",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://datatracker.ietf.org/doc/html/rfc8785",
+      "relation": "cites",
+      "scheme": "url"
+    }
+  ]
+}


### PR DESCRIPTION
Zenodo reads repository metadata when archiving a GitHub release. `CITATION.cff` alone gives it a title and licence; `.zenodo.json` adds the abstract, publication type, keywords, and the relation to RFC 8785.

Two things still have to happen before a DOI exists, neither of them this file:

1. The Zenodo GitHub app has to be authorised for this repository (interactive, at `zenodo.org/account/settings/github/`)
2. A release has to be cut

**No release has ever been cut here.** Worth fixing on its own: a specification at v2.0 with no tagged release is awkward to cite and impossible to pin a dependency against.

Creators stay `"Context Passport maintainers"` to match `CITATION.cff`. That is weaker for citation indexing than a personal name and is a deliberate choice.