### PR TITLE
Point at the DOI, which nothing did

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,7 @@ type: software
 license: CC0-1.0
 url: https://contextpassport.com
 repository-code: https://github.com/contextpassport/spec
+doi: 10.5281/zenodo.22153488
 authors:
   - name: "Context Passport maintainers"
 keywords:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Version 2.0 · Spec: CC0 1.0 · Reference implementations: Apache-2.0
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22153488.svg)](https://doi.org/10.5281/zenodo.22153488)
+
 ---
 
 Context Passport is a minimal JSON schema for structured, verifiable records of AI agent events — decisions, handoffs, checkpoints, forks, audits, and consent. Model-agnostic. Framework-agnostic. Cryptographically verifiable.
@@ -96,6 +98,21 @@ Context Passport is a community-governed open standard. We are actively looking 
 Governance and decision-making are documented in [`GOVERNANCE.md`](GOVERNANCE.md). Code of conduct in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). Security reports to `security@contextpassport.com` ([`SECURITY.md`](SECURITY.md)).
 
 ## License
+
+## Citing this specification
+
+Archived on Zenodo, so it can be cited in research, regulatory filings and
+standards work without depending on a branch URL that may move.
+
+**DOI: [10.5281/zenodo.22153488](https://doi.org/10.5281/zenodo.22153488)**
+
+That is the *concept* DOI: it always resolves to the newest published version.
+Cite it when you mean the specification. Each release also mints a version DOI
+pinned to one exact snapshot, listed on the Zenodo record, for when you need to
+name the version you actually implemented.
+
+The archive is CC0, like the specification. Nothing about citing it creates an
+obligation to anyone.
 
 The **specification** (SPEC.md, schema/, README.md content) is released under **CC0 1.0 Universal** — no rights reserved, public domain. Implement it, fork it, extend it. No attribution required.
 


### PR DESCRIPTION
The Zenodo archive was minted this morning (`10.5281/zenodo.22153489` for v2.0.1) and **no file in this repository mentioned it**. An archive nobody can find is a backup, not an archive.

Adds the badge, a short citation section, and a `doi:` field in `CITATION.cff` — the last one is what makes GitHub's own *Cite this repository* button return something.

**Uses the concept DOI, not the version DOI.** `10.5281/zenodo.22153488` always resolves to the newest release, which is what someone citing *the specification* means. The version DOI names one exact snapshot and belongs in a citation only when the implemented version actually matters. The README says so explicitly, because getting this backwards is the common error and a citation pinned to 2.0.1 forever will quietly rot as the spec moves.

`npm test` passes.