### PR TITLE
ci: move the workflows onto Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Validate examples against schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
       - run: npm install --no-save ajv ajv-formats canonicalize
@@ -32,8 +32,8 @@ jobs:
     name: Documented code still runs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       # Offline mode needs no API key and makes no network call, so the
@@ -47,7 +47,7 @@ jobs:
       - run: python tools/check-quickstart.py
       # Same contract for the TypeScript quickstart: extract its blocks, run
       # them against the published SDK, assert the documented booleans.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
       - run: npm install --no-save @contextpassport/core@^2.0.0 tsx

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -52,7 +52,7 @@ jobs:
   steward:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Every workflow run in this repository now ends with a deprecation warning:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/checkout@v4
```

Seen on the Steward run from this morning: https://github.com/contextpassport/spec/actions/runs/33251987167

The runner is already executing these actions on Node 24 whatever they ask for, so the current pins buy nothing today and stop working whenever that forcing is withdrawn. Bumping to the majors that target Node 24 makes the workflow declare what is actually happening rather than relying on a compatibility shim that is scheduled to go away.

## What changed

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |

Six pins across `ci.yml` and `steward.yml`. Nothing else in either file is touched. The only inputs these workflows pass are `node-version` and `python-version`, both unchanged across the bump, so there is no behavioural change to review beyond the runtime.

## Verification

CI on this PR is the check that matters: it runs the same three jobs on the new action versions. Before opening it I ran the suite locally against `main` so a failure here would be attributable to the bump rather than to pre-existing breakage:

```
$ node tools/validate-examples.mjs
  Context Passport, validating 17 example file(s) against schema/v2.json
  ...
  All examples valid: schema, recomputed hashes, and chain linkage.

$ python tools/check-quickstart.py
docs/quickstart.md runs as written: 5 blocks, results as documented.

$ node tools/check-quickstart-ts.mjs
docs/quickstart-typescript.md runs as written: 5 blocks, results as documented.

$ python examples/integrations/anthropic_sdk.py --offline
verify_chain -> True
after editing step 0's output -> False
```

## Not in this PR

The same three pins appear in `contextpassport/python`, `contextpassport/typescript` and `contextpassport/conformance-tests`. They need the identical change and will get their own pull requests.

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7U6Tk3mT9LfKM5hQ3TF1)_