### PR TITLE
fix: server.js served any file the web process could read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           node-version: '20'
       - run: npm install --no-save ajv ajv-formats canonicalize
       - run: node tools/validate-examples.mjs
+      # server.js serves contextpassport.com. It previously joined the raw
+      # request path onto the site root with no containment check, which made
+      # every file the web process could read fetchable over HTTP. Checked here
+      # so it cannot come back quietly.
+      - run: node tools/check-server.mjs
 
   docs-and-examples:
     name: Documented code still runs

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "npx serve . --listen ${PORT:-3000} --no-clipboard",
-    "test": "node tools/validate-examples.mjs"
+    "test": "node tools/validate-examples.mjs && node tools/check-server.mjs"
   },
   "dependencies": {
     "serve": "^14.0.0"

--- a/server.js
+++ b/server.js
@@ -3,6 +3,39 @@ const fs   = require('fs');
 const path = require('path');
 const port = process.env.PORT || 3000;
 
+// Every path served is resolved against this and then checked to be inside it.
+// realpath so that the comparison holds if the checkout itself sits behind a
+// symlink, which would otherwise make every request look like an escape.
+const ROOT = fs.realpathSync(__dirname);
+
+/**
+ * Resolve a request path to a file inside ROOT, or null if it points outside.
+ *
+ * req.url is the raw request target and Node does not normalize it, so a
+ * client writing to the socket directly can send "GET /../../etc/passwd".
+ * path.join would happily resolve that to a real file outside the site root,
+ * which is an arbitrary file read. Browsers collapse the dot segments before
+ * sending, which is why this does not show up in ordinary use.
+ *
+ * Decoding happens before the containment check, otherwise %2e%2e walks up
+ * just as well as "..".
+ */
+function resolveWithinRoot(urlPath) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(urlPath);
+  } catch {
+    return null;   // malformed percent-encoding
+  }
+  if (decoded.includes('\0')) return null;
+
+  // The leading "." keeps an absolute decoded path from escaping ROOT: resolve
+  // would otherwise take "/etc/passwd" as the final, absolute answer.
+  const candidate = path.resolve(ROOT, '.' + decoded);
+  if (candidate !== ROOT && !candidate.startsWith(ROOT + path.sep)) return null;
+  return candidate;
+}
+
 const mime = {
   '.html': 'text/html',
   '.css':  'text/css',
@@ -22,7 +55,9 @@ http.createServer((req, res) => {
     fs.stat(candidate, (statErr, stats) => {
       if (statErr) { onMiss(); return; }
       if (stats.isDirectory()) {
-        // Directory request: try <dir>/index.html
+        // Directory request: try <dir>/index.html. Safe to join without a
+        // second check, since candidate is already inside ROOT and the
+        // appended segment is a constant.
         const indexCandidate = path.join(candidate, 'index.html');
         fs.readFile(indexCandidate, (idxErr, idxData) => {
           if (idxErr) { onMiss(); return; }
@@ -40,16 +75,23 @@ http.createServer((req, res) => {
     });
   };
 
-  const filePath = path.join(__dirname, urlPath);
-
-  tryServe(filePath, () => {
+  const serveIndex = () => {
     // Fallback to root index.html for SPA-style routing of unknown paths
-    fs.readFile(path.join(__dirname, 'index.html'), (err2, data2) => {
+    fs.readFile(path.join(ROOT, 'index.html'), (err2, data2) => {
       if (err2) { res.writeHead(404); res.end('Not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(data2);
     });
-  });
+  };
+
+  const filePath = resolveWithinRoot(urlPath);
+
+  // A path pointing outside the root is treated as a miss rather than as its
+  // own status code. It gets the same response an unknown path gets, so the
+  // reply says nothing about what does or does not exist out there.
+  if (filePath === null) { serveIndex(); return; }
+
+  tryServe(filePath, serveIndex);
 }).listen(port, () => {
   console.log(`Context Passport running on port ${port}`);
 });

--- a/tools/check-server.mjs
+++ b/tools/check-server.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Asserts that server.js serves the site and nothing else.
+ *
+ * This exists because it did not. server.js joined the raw request path onto
+ * the site root with no containment check, and since Node does not normalize
+ * req.url, a client writing to the socket directly could ask for
+ * "GET /../../../etc/passwd" and get it back with 200 OK. Browsers collapse
+ * dot segments before sending, so ordinary use never showed it.
+ *
+ * The escape cases below are therefore written against a raw socket rather
+ * than fetch(), because fetch normalizes the path and would quietly test
+ * nothing at all. That is the trap this file is guarding, so it has to be
+ * avoided here first.
+ */
+
+import { spawn } from 'node:child_process';
+import { connect } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = 34871;   // unlikely to collide with anything a contributor is running
+
+/** Send a raw request line without normalization and return the response text. */
+function rawRequest(target) {
+  return new Promise((resolve, reject) => {
+    const socket = connect(PORT, '127.0.0.1', () => {
+      socket.write(`GET ${target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    });
+    let out = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => { out += chunk; });
+    socket.on('end', () => resolve(out));
+    socket.on('error', reject);
+    socket.setTimeout(10000, () => { socket.destroy(); reject(new Error(`timeout on ${target}`)); });
+  });
+}
+
+const waitFor = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(attempts = 40) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      await rawRequest('/');
+      return true;
+    } catch {
+      await waitFor(250);
+    }
+  }
+  return false;
+}
+
+const server = spawn(process.execPath, [join(ROOT, 'server.js')], {
+  cwd: ROOT,
+  env: { ...process.env, PORT: String(PORT) },
+  stdio: 'ignore',
+});
+
+let failures = 0;
+const pass = (msg) => console.log(`  ok    ${msg}`);
+const fail = (msg) => { failures++; console.error(`  FAIL  ${msg}`); };
+
+try {
+  if (!await waitForServer()) {
+    console.error('server.js did not start');
+    process.exit(1);
+  }
+
+  console.log('\n  Context Passport, checking server.js\n');
+
+  // The site still works. A traversal fix that breaks serving is not a fix.
+  const schema = await rawRequest('/schema/v2.json');
+  if (schema.startsWith('HTTP/1.1 200') && schema.includes('"$id"') && schema.includes('contextpassport.com/schema/v2.json')) {
+    pass('serves /schema/v2.json');
+  } else {
+    fail('did not serve /schema/v2.json');
+  }
+
+  const index = await rawRequest('/');
+  if (index.startsWith('HTTP/1.1 200') && index.includes('text/html')) {
+    pass('serves / as html');
+  } else {
+    fail('did not serve / as html');
+  }
+
+  const unknown = await rawRequest('/no-such-page');
+  if (unknown.startsWith('HTTP/1.1 200') && unknown.includes('text/html')) {
+    pass('unknown path falls back to index.html');
+  } else {
+    fail('unknown path did not fall back to index.html');
+  }
+
+  // Nothing outside the site root is reachable, however the path is spelled.
+  const escapes = [
+    ['/../../../etc/passwd', 'root:x:0:0'],
+    ['/../../etc/passwd', 'root:x:0:0'],
+    ['/./../../etc/passwd', 'root:x:0:0'],
+    ['/%2e%2e/%2e%2e/%2e%2e/etc/passwd', 'root:x:0:0'],
+    ['/..%2f..%2f..%2fetc%2fpasswd', 'root:x:0:0'],
+    ['/subdir/../../../etc/passwd', 'root:x:0:0'],
+  ];
+
+  for (const [target, leak] of escapes) {
+    const body = await rawRequest(target);
+    if (body.includes(leak)) {
+      fail(`escaped the site root: ${target}`);
+    } else {
+      pass(`contained: ${target}`);
+    }
+  }
+
+  // A file that exists in the repo but is not part of the published site is
+  // still inside the root, so this is not a traversal case. It is here to
+  // record that containment is the property being tested, not an allow-list.
+  const inRoot = await rawRequest('/package.json');
+  if (inRoot.startsWith('HTTP/1.1 200')) {
+    pass('files inside the root remain reachable');
+  } else {
+    fail('a file inside the root became unreachable');
+  }
+
+  if (failures === 0) {
+    console.log('\n  server.js serves the site root and nothing outside it.\n');
+  } else {
+    console.error(`\n  ${failures} check(s) failed.\n`);
+  }
+} finally {
+  server.kill();
+}
+
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
`server.js` built the path it serves with `path.join(__dirname, req.url)` and never checked that the result stayed inside the site root.

`req.url` is the raw request target and Node does not normalize it, so a client writing to the socket directly can send:

```
GET /../../../etc/passwd HTTP/1.1
```

and get the file back with `200 OK`. This is confirmed against the current `server.js` rather than inferred from reading it:

```
$ printf 'GET /../../../etc/passwd HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' | nc 127.0.0.1 3000
HTTP/1.1 200 OK
Content-Type: text/plain

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...
```

Anything the web process can read was readable over HTTP. The README describes this file as what serves contextpassport.com, so on that host the exposure is whatever else lives on the machine, not just this repository.

It went unnoticed because browsers collapse dot segments before sending the request, so no amount of ordinary use reaches it. Only a raw socket does.

## The fix

Resolve the request path against the site root, then require the result to still be inside it.

Three details worth reviewing rather than skimming:

- **Decoding happens before the containment check.** `%2e%2e` walks up just as well as `..`. The old code never decoded at all, so it happened not to be reachable that way; adding decoding without the check would have opened a second door. Malformed encoding is rejected rather than passed through.
- **An out-of-root path is treated as a miss**, not given its own status code. It gets the same `index.html` fallback an unknown path gets, so the response says nothing about what does or does not exist outside the root.
- **`ROOT` is `realpath`'d**, so a checkout sitting behind a symlink does not make every request look like an escape.

## The test

`tools/check-server.mjs` asserts both halves: the site is still served, and six spellings of an escape all stay contained. A traversal fix that breaks serving is not a fix, so the positive cases matter as much as the negative ones.

Its requests go over a raw socket rather than `fetch()`. `fetch` normalizes the path, so a test written the obvious way would send `/etc/passwd` instead of `/../../../etc/passwd` and pass against the vulnerable server while testing nothing. That is precisely the trap this file exists to guard, so it had to be avoided in the test first.

I verified the test fails against the previous `server.js` and passes against this one, rather than only checking that it passes now:

```
--- against the unfixed server.js ---
  ok    serves /schema/v2.json
  ok    serves / as html
  ok    unknown path falls back to index.html
  FAIL  escaped the site root: /../../../etc/passwd
  ...
  1 check(s) failed.
exit=1

--- against this branch ---
  ok    serves /schema/v2.json
  ok    serves / as html
  ok    unknown path falls back to index.html
  ok    contained: /../../../etc/passwd
  ok    contained: /../../etc/passwd
  ok    contained: /./../../etc/passwd
  ok    contained: /%2e%2e/%2e%2e/%2e%2e/etc/passwd
  ok    contained: /..%2f..%2f..%2fetc%2fpasswd
  ok    contained: /subdir/../../../etc/passwd
  ok    files inside the root remain reachable

  server.js serves the site root and nothing outside it.
exit=0
```

Note in the failing run that only the three-level escape hit. Two levels up from the checkout was a directory with no `etc/passwd` under it, so a shallower probe missed. The depth that works depends on where the site is deployed, which is a good reason not to treat a single negative probe as evidence of safety.

Wired into `npm test` and into the CI job that already validates the examples.

## Deployment

Worth checking separately from this PR: whether the host serving contextpassport.com actually runs this file, and if so what was reachable. I could not reach that host from where this ran, so I cannot answer it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7U6Tk3mT9LfKM5hQ3TF1)_