### PR TITLE
fix: stop serving the .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# The Dockerfile is `COPY . .`, so without this the image carries the whole
+# VCS history and it is reachable over HTTP from the site root. server.js also
+# refuses to serve .git, but keeping it out of the image is the better of the
+# two defences: what is not there cannot be served however the server changes.
+.git
+.github
+
+# Never part of the published site, and only ever arrive by accident.
+node_modules
+.env
+*.log

--- a/server.js
+++ b/server.js
@@ -8,6 +8,14 @@ const port = process.env.PORT || 3000;
 // symlink, which would otherwise make every request look like an escape.
 const ROOT = fs.realpathSync(__dirname);
 
+// Paths inside the root that are still not part of the published site.
+//
+// Deliberately a narrow list rather than "reject anything starting with a dot".
+// The specification's own examples reference /.well-known/cp-revoked-keys.json
+// and /.well-known/did.json, so a blanket rule on dotfiles would block a path
+// this site has a stated reason to serve one day.
+const DENIED_SEGMENTS = new Set(['.git']);
+
 /**
  * Resolve a request path to a file inside ROOT, or null if it points outside.
  *
@@ -33,6 +41,15 @@ function resolveWithinRoot(urlPath) {
   // would otherwise take "/etc/passwd" as the final, absolute answer.
   const candidate = path.resolve(ROOT, '.' + decoded);
   if (candidate !== ROOT && !candidate.startsWith(ROOT + path.sep)) return null;
+
+  // Checked on the resolved path rather than on the request text, so that
+  // spellings like /foo/../.git/config are caught after normalization rather
+  // than being compared against as written.
+  const relative = path.relative(ROOT, candidate);
+  if (relative && relative.split(path.sep).some((segment) => DENIED_SEGMENTS.has(segment))) {
+    return null;
+  }
+
   return candidate;
 }
 

--- a/tools/check-server.mjs
+++ b/tools/check-server.mjs
@@ -110,6 +110,36 @@ try {
     }
   }
 
+  // .git sits inside the root, so containment alone does not cover it. The
+  // Dockerfile is COPY . ., which means the deployed image carries the whole
+  // history unless something refuses to serve it.
+  const gitPaths = [
+    ['/.git/config', 'repositoryformatversion'],
+    ['/.git/HEAD', 'ref:'],
+    ['/foo/../.git/config', 'repositoryformatversion'],
+    ['/%2egit/config', 'repositoryformatversion'],
+  ];
+
+  for (const [target, leak] of gitPaths) {
+    const body = await rawRequest(target);
+    if (body.includes(leak)) {
+      fail(`served the git directory: ${target}`);
+    } else {
+      pass(`refused: ${target}`);
+    }
+  }
+
+  // The specification's examples reference /.well-known paths, so the rule
+  // above has to be narrower than "reject anything beginning with a dot".
+  // There is no .well-known directory yet; what matters is that the request
+  // reaches the normal miss path rather than being rejected out of hand.
+  const wellKnown = await rawRequest('/.well-known/did.json');
+  if (wellKnown.startsWith('HTTP/1.1 200') && wellKnown.includes('text/html')) {
+    pass('/.well-known is not blanket-denied');
+  } else {
+    fail('/.well-known was denied, which would block a documented path');
+  }
+
   // A file that exists in the repo but is not part of the published site is
   // still inside the root, so this is not a traversal case. It is here to
   // record that containment is the property being tested, not an allow-list.


### PR DESCRIPTION
Follow-up to #62. That PR established that nothing *outside* the site root is reachable. `.git` is *inside* the root, so it was not covered, and the Dockerfile is `COPY . .`, which means the deployed image carries the whole VCS history and served it:

```
$ printf 'GET /.git/config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' | nc 127.0.0.1 3000
HTTP/1.1 200 OK
Content-Type: text/plain

[core]
	repositoryformatversion = 0
...
[remote "origin"]
	url = https://github.com/contextpassport/spec
```

This repository is public, so the history is not itself a secret and this is a materially smaller problem than the traversal was. It is still wrong. Serving `.git` hands over packfiles and reflogs rather than the published tree, which includes anything ever committed and later removed, and that exposure outlives the deletion.

## Two defences, because they fail differently

**`.dockerignore`** keeps `.git` and `.github` out of the image entirely. What is not there cannot be served however the server changes later, so this is the better of the two. It only covers the Docker path though, not a deploy that clones the repo and runs `server.js` directly.

**`server.js`** refuses any resolved path containing a `.git` segment, which covers both deployment shapes.

The deny list is deliberately narrow rather than "reject anything beginning with a dot". `SPEC.md`'s own examples reference `/.well-known/cp-revoked-keys.json` and `/.well-known/did.json`, so a blanket dot rule would block a path this site has a stated reason to serve one day. There is a test asserting `/.well-known` still reaches the normal miss path.

The check runs on the resolved path rather than on the request text, so `/foo/../.git/config` is caught after normalization rather than compared against as written. `/%2egit/config` matters specifically: #62 added percent-decoding, which made that a live spelling, and it is covered for exactly that reason.

## Verification

The four new cases fail against the previous `server.js` and pass against this branch:

```
--- against main ---
  FAIL  served the git directory: /.git/config
  FAIL  served the git directory: /.git/HEAD
  FAIL  served the git directory: /foo/../.git/config
  FAIL  served the git directory: /%2egit/config
  ok    /.well-known is not blanket-denied

--- against this branch ---
  ok    refused: /.git/config
  ok    refused: /.git/HEAD
  ok    refused: /foo/../.git/config
  ok    refused: /%2egit/config
  ok    /.well-known is not blanket-denied
  ok    files inside the root remain reachable
```

Full suite green, including everything #62 added.

One gap worth stating rather than glossing: the `.dockerignore` is not build-tested. There is no docker daemon available where this ran, so I could not build the image and confirm `.git` is absent from it. The `server.js` half is the defence that is actually covered by tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7U6Tk3mT9LfKM5hQ3TF1)_