### PR TITLE
ci: watch the schema SchemaStore now points editors at

### DIFF
--- a/.github/workflows/published-schema.yml
+++ b/.github/workflows/published-schema.yml
@@ -1,0 +1,28 @@
+name: Published schema
+
+# Watches the schema actually served at contextpassport.com, which SchemaStore
+# has pointed every VS Code, Visual Studio and JetBrains install at since
+# SchemaStore/schemastore#6264 merged on 28 August 2026.
+#
+# Deliberately not on push or pull_request. A pull request that edits
+# schema/v2.json would fail this check for the honest reason that the site has
+# not been redeployed yet, and a check that cries wolf on correct work is a
+# check people learn to ignore. The risk here is drift over time and the site
+# going down, neither of which is caused by a commit, so a daily schedule
+# catches it and a push trigger would not.
+
+on:
+  schedule:
+    - cron: '47 5 * * *'   # daily, 05:47 UTC
+  workflow_dispatch:
+
+jobs:
+  published-schema:
+    name: Served schema matches this repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+      - run: node tools/check-published-schema.mjs

--- a/SPEC.md
+++ b/SPEC.md
@@ -404,7 +404,15 @@ transporting passports.
 import json, hashlib, math, time, secrets
 
 def _normalize(value):
-    """JCS number normalization: reject non-finite, fold integer-valued floats to int."""
+    """JCS normalization: key order, non-finite rejection, integer-valued float folding.
+
+    Keys are ordered by UTF-16 code unit, per RFC 8785 3.2.3. Python's sorted()
+    and json.dumps(sort_keys=True) order by code point instead, which agrees
+    across the whole BMP and disagrees above it: U+1F600 encodes to the surrogate
+    pair D83D DE00, so it sorts below U+FF01 in UTF-16 and above it by code
+    point. A payload with an emoji key hashes differently under the two, so this
+    is not a detail an implementation can skip.
+    """
     if isinstance(value, bool) or value is None:
         return value
     if isinstance(value, float):
@@ -414,7 +422,10 @@ def _normalize(value):
             return 0
         return int(value) if value.is_integer() else value
     if isinstance(value, dict):
-        return {k: _normalize(v) for k, v in value.items()}
+        # Dicts preserve insertion order, so building in JCS order here means
+        # json.dumps can serialize with sort_keys=False and be correct.
+        return {k: _normalize(value[k])
+                for k in sorted(value, key=lambda s: s.encode("utf-16-be"))}
     if isinstance(value, (list, tuple)):
         return [_normalize(v) for v in value]
     return value  # int, str
@@ -427,8 +438,9 @@ def make_passport(agent_id, agent_name, payload, parent=None,
     hex_  = secrets.token_hex(6)
     ctx_id = f"ctx_{ts}_{hex_}"
 
-    # RFC 8785 (JCS) canonicalization: sorted keys, raw UTF-8, normalized numbers.
-    canonical  = json.dumps(_normalize(payload), sort_keys=True, ensure_ascii=False,
+    # RFC 8785 (JCS): keys already in UTF-16 order from _normalize, raw UTF-8,
+    # normalized numbers. sort_keys must stay False or Python re-sorts by code point.
+    canonical  = json.dumps(_normalize(payload), sort_keys=False, ensure_ascii=False,
                             separators=(',', ':'))
     pay_hash   = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -484,7 +496,7 @@ def verify_chain(passports):
     """Returns True if chain is intact, False if any hash mismatch detected."""
     prev = None
     for p in passports:
-        canonical  = json.dumps(_normalize(p["payload"]), sort_keys=True,
+        canonical  = json.dumps(_normalize(p["payload"]), sort_keys=False,
                                 ensure_ascii=False, separators=(',', ':'))
         pay_hash   = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
         parent_hash = prev["integrity"]["integrity_hash"] if prev else None

--- a/tools/check-published-schema.mjs
+++ b/tools/check-published-schema.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Asserts that the schema served at contextpassport.com is the schema in this
+ * repository.
+ *
+ * That URL stopped being a convenience on 28 August 2026, when SchemaStore
+ * merged a catalog entry pointing at it (SchemaStore/schemastore#6264). Every
+ * VS Code, Visual Studio and JetBrains install now fetches it whenever someone
+ * opens a *.passport.json file. Nobody who hits a stale or missing copy will
+ * know to tell us: they will see validation errors on a valid document, blame
+ * the format, and close the file.
+ *
+ * The failure this guards is silent by construction. A deploy that does not
+ * happen leaves the repository correct and the world wrong, so nothing in the
+ * commit history looks off. Only fetching the live bytes catches it, which is
+ * why this runs on a schedule rather than on push: the risk is drift over
+ * time, not a bad diff.
+ *
+ *     node tools/check-published-schema.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const LOCAL = join(ROOT, 'schema', 'v2.json');
+const PUBLISHED = 'https://contextpassport.com/schema/v2.json';
+
+// Compare canonically so key order in the served file cannot raise a false
+// alarm. What matters is that the two describe the same constraints.
+const canon = (v) =>
+  JSON.stringify(v, (_, x) =>
+    x && typeof x === 'object' && !Array.isArray(x)
+      ? Object.fromEntries(Object.keys(x).sort().map((k) => [k, x[k]]))
+      : x,
+  );
+
+/**
+ * Returns an array of failure strings. Empty means the published schema is
+ * good. Never calls process.exit: exiting hard while an undici keep-alive
+ * socket is open aborts the process with a libuv assertion on Windows, which
+ * surfaces as exit 127 and a C-level stack trace instead of the readable
+ * failure this file exists to produce.
+ */
+async function check() {
+  const res = await fetch(PUBLISHED, { headers: { accept: 'application/json' } });
+
+  if (res.status !== 200) {
+    return [
+      `${PUBLISHED} returned ${res.status} ${res.statusText}`,
+      'SchemaStore points editors at this URL. While it is down, every',
+      '*.passport.json file in every IDE fails to validate.',
+    ];
+  }
+
+  // Editors and validators dispatch on this. text/html here usually means a
+  // catch-all route swallowed the path and returned the site index with a 200,
+  // which is worse than a 404: it parses as "not a schema" rather than "not
+  // there", so the editor reports the user's document as the problem.
+  const ctype = (res.headers.get('content-type') ?? '').split(';')[0].trim();
+  const body = await res.text();
+
+  let published;
+  try {
+    published = JSON.parse(body);
+  } catch (e) {
+    return [
+      `the published schema is not valid JSON: ${e.message}`,
+      `first 200 bytes: ${body.slice(0, 200)}`,
+    ];
+  }
+
+  const local = JSON.parse(readFileSync(LOCAL, 'utf8'));
+  const problems = [];
+
+  if (ctype !== 'application/json') {
+    problems.push(`content-type is "${ctype}", expected "application/json"`);
+  }
+
+  if (canon(published) !== canon(local)) {
+    problems.push('the published schema differs from schema/v2.json');
+    const pk = Object.keys(published);
+    const lk = Object.keys(local);
+    for (const k of pk.filter((k) => !lk.includes(k))) problems.push(`  only published: ${k}`);
+    for (const k of lk.filter((k) => !pk.includes(k))) problems.push(`  only in repo:   ${k}`);
+    for (const k of pk.filter((k) => lk.includes(k))) {
+      if (canon(published[k]) !== canon(local[k])) problems.push(`  differs:        ${k}`);
+    }
+    problems.push("  The site needs redeploying, or the repo needs the site's version.");
+  }
+
+  // A schema whose $id disagrees with where it is served from resolves any
+  // future $ref against the wrong base, and tells a reader it came from
+  // somewhere else.
+  if (published.$id !== PUBLISHED) {
+    problems.push(`$id is "${published.$id}", expected "${PUBLISHED}"`);
+  }
+
+  if (problems.length === 0) {
+    console.log(`Published schema matches schema/v2.json (${body.length} bytes, ${ctype}, $id ok).`);
+  }
+  return problems;
+}
+
+const problems = await check();
+if (problems.length > 0) {
+  for (const p of problems) console.error(p.startsWith(' ') ? p : `FAIL  ${p}`);
+  console.error('\nSchemaStore catalog: https://www.schemastore.org/api/json/catalog.json');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Follow-up to SchemaStore/schemastore#6264, merged yesterday.

That catalog entry points every VS Code, Visual Studio and JetBrains install at `https://contextpassport.com/schema/v2.json` whenever someone opens a `*.passport.json` file. It is live in the published catalog now, one of 1,441 entries. Nothing in this repository watched that URL.

The failure mode is silent by construction. If the site drifts from the repo or goes down, the repo stays correct, no diff looks wrong, and we do not find out. The people who do find out are strangers seeing validation errors on a valid document, who will blame the format rather than the deploy.

### What it checks

- HTTP 200
- `content-type: application/json`. This matters on its own: a catch-all route returning the site index with a 200 parses as "not a schema" rather than "not there", which is the worse of the two failures
- Body is valid JSON
- Canonical deep-equality against `schema/v2.json`, so key order cannot raise a false alarm
- `$id` matches the URL it is served from

### Why schedule and not push

A PR that edits `schema/v2.json` would fail this check for the honest reason that the site has not redeployed yet. A check that cries wolf on correct work is one people learn to ignore. The risk here is drift over time and downtime, neither caused by a commit, so daily catches it and a push trigger would not.

### Verified both directions

```
$ node tools/check-published-schema.mjs
Published schema matches schema/v2.json (4713 bytes, application/json, $id ok).
EXIT=0
```

and with a deliberately altered local schema:

```
FAIL  the published schema differs from schema/v2.json
  differs:        properties
  The site needs redeploying, or the repo needs the site's version.
EXIT=1
```

The first draft called `process.exit()` and aborted with a libuv assertion on Windows, exit 127, because an undici keep-alive socket was still open. It sets `process.exitCode` instead.