### PR TITLE
Acknowledge the star baseline so the adoption alert stops crying wolf

### DIFF
--- a/.github/adoption.json
+++ b/.github/adoption.json
@@ -5,7 +5,7 @@
     "typescript": 0,
     "mcp": 0,
     "forks": 5,
-    "stars": 1,
+    "stars": 2,
     "tinker": 0
   }
 }


### PR DESCRIPTION
The Steward run this morning failed on a risen signal. I dispatched it during the daily sweep and read the output rather than inferring it:

```
Adoption signals

  records          0
  python           0
  typescript       0
  mcp              0
  tinker           0
  forks            5
  stars            2  (up from 1)

Risen since last check:
  stars: 1 -> 2
```

So the rise is one star on this repository. Every signal that would mean somebody is actually using the format is still zero: no record committed to a public repo, no import of either reference SDK, no MCP tool use, no Tinker run. This is not the news the alert exists to deliver.

Recording it rather than leaving it ringing, for one reason. The baseline is updated by hand precisely so a rise keeps alarming until a person looks, and a person has now looked. But this alert has exactly one job, which is to be believed on the day `records` goes from 0 to 1. A weekly failure mail about a single star is how an alert gets filtered into a folder nobody opens, and the one that matters would then arrive in that same folder.

Only the `stars` count changes. The numbers here are the ones the failing run printed for pasting, so the next run compares against a true baseline rather than a stale one.

Worth flagging separately, and not fixed here: the Steward's "contributions awaiting a reply" step only scans `contextpassport/spec`. It reported "Nothing is waiting on a reply" this morning while two outside pull requests sat unanswered in the SDK repos. Raised as #68.