### PR TITLE
fix: scan all Context Passport repos in Steward contribution check

### DIFF
--- a/.github/adoption-check.mjs
+++ b/.github/adoption-check.mjs
@@ -45,7 +45,16 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
 const STATE = '.github/adoption.json';
-const repo = process.env.REPO || 'contextpassport/spec';
+const DEFAULT_REPOS = [
+  'contextpassport/spec',
+  'contextpassport/python',
+  'contextpassport/typescript',
+  'contextpassport/conformance-tests',
+  'contextpassport/verifiable-agent-template',
+];
+const repos = (process.env.REPOS || process.env.REPO || DEFAULT_REPOS.join(' '))
+  .split(/\s+/)
+  .filter(Boolean);
 
 // Queries chosen to be specific enough that a hit is real. Broad ones like
 // `"schema_version": "2.0"` return thousands of unrelated files and are
@@ -86,12 +95,19 @@ function codeSearchRepos(query) {
 }
 
 function repoStats() {
-  try {
-    const out = gh(['api', `repos/${repo}`, '--jq', '{forks: .forks_count, stars: .stargazers_count}']);
-    return JSON.parse(out);
-  } catch {
-    return {};
+  let forks = 0;
+  let stars = 0;
+  for (const repo of repos) {
+    try {
+      const out = gh(['api', `repos/${repo}`, '--jq', '{forks: .forks_count, stars: .stargazers_count}']);
+      const stats = JSON.parse(out);
+      forks += stats.forks || 0;
+      stars += stats.stars || 0;
+    } catch {
+      // A single failed lookup must not erase the aggregate.
+    }
   }
+  return { forks, stars };
 }
 
 // ---------------------------------------------------------------- gather

--- a/.github/adoption-check.mjs
+++ b/.github/adoption-check.mjs
@@ -26,7 +26,8 @@
  *                whereas "tinker.finetune_started" appears only where somebody
  *                actually recorded one. This is the argument for namespacing
  *                custom event types generally, not just here.
- *   forks/stars  weaker, but a fork is a deliberate act.
+ *   forks_*/stars_* per repository. Weaker than a code hit, but a fork is a
+ *                deliberate act and the repo prefix tells the owner which one moved.
  *
  * State lives in .github/adoption.json, which deliberately carries no
  * timestamp: it should change only when a signal changes, so its git history
@@ -95,19 +96,19 @@ function codeSearchRepos(query) {
 }
 
 function repoStats() {
-  let forks = 0;
-  let stars = 0;
+  const stats = {};
   for (const repo of repos) {
+    const short = repo.split('/')[1];
     try {
       const out = gh(['api', `repos/${repo}`, '--jq', '{forks: .forks_count, stars: .stargazers_count}']);
-      const stats = JSON.parse(out);
-      forks += stats.forks || 0;
-      stars += stats.stars || 0;
+      const { forks, stars } = JSON.parse(out);
+      stats[`forks_${short}`] = forks;
+      stats[`stars_${short}`] = stars;
     } catch {
-      // A single failed lookup must not erase the aggregate.
+      // A single failed lookup must not erase the baseline for other repos.
     }
   }
-  return { forks, stars };
+  return stats;
 }
 
 // ---------------------------------------------------------------- gather

--- a/.github/adoption-check.mjs
+++ b/.github/adoption-check.mjs
@@ -26,7 +26,8 @@
  *                whereas "tinker.finetune_started" appears only where somebody
  *                actually recorded one. This is the argument for namespacing
  *                custom event types generally, not just here.
- *   forks_*/stars_* per repository. Weaker than a code hit, but a fork is a
+ *   forks_<repo>, stars_<repo>
+ *                per repository. Weaker than a code hit, but a fork is a
  *                deliberate act and the repo prefix tells the owner which one moved.
  *
  * State lives in .github/adoption.json, which deliberately carries no

--- a/.github/adoption.json
+++ b/.github/adoption.json
@@ -4,8 +4,16 @@
     "python": 0,
     "typescript": 0,
     "mcp": 0,
-    "forks": 5,
-    "stars": 2,
-    "tinker": 0
+    "tinker": 0,
+    "forks_spec": 5,
+    "stars_spec": 2,
+    "forks_python": 2,
+    "stars_python": 0,
+    "forks_typescript": 2,
+    "stars_typescript": 0,
+    "forks_conformance-tests": 0,
+    "stars_conformance-tests": 0,
+    "forks_verifiable-agent-template": 0,
+    "stars_verifiable-agent-template": 0
   }
 }

--- a/.github/steward-check.mjs
+++ b/.github/steward-check.mjs
@@ -7,19 +7,17 @@
  * — reviews. An item counts as "awaiting reply" when:
  *
  *   - it was opened by someone who is not a maintainer and not a bot, and
- *   - no maintainer for that repository has commented or submitted a review, and
+ *   - no maintainer has commented or submitted a review, and
  *   - it is older than GRACE_DAYS.
  *
- * Maintainers are resolved per repository (push access on that repo only), so
- * a collaborator in one repository is never treated as a maintainer elsewhere.
- *
- * Cross-repo reads require STEWARD_TOKEN (a PAT or GitHub App installation
- * token with issues, pull-requests, and administration read on the listed
- * repositories — collaborator listing needs administration read).
+ * Maintainers are read from .github/CODEOWNERS in the checkout, which
+ * GOVERNANCE.md names as the authoritative list. No repository secret is
+ * required: issue, pull request, comment, and review data are public reads.
  *
  * Exit 1 makes GitHub email the repository owner. Nothing is posted publicly.
  */
 
+import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
 const DEFAULT_REPOS = [
@@ -30,40 +28,44 @@ const DEFAULT_REPOS = [
   'contextpassport/verifiable-agent-template',
 ];
 
+const CODEOWNERS = '.github/CODEOWNERS';
+
 const repos = (process.env.REPOS || process.env.REPO || DEFAULT_REPOS.join(' '))
   .split(/\s+/)
   .filter(Boolean);
 const graceDays = Number(process.env.GRACE_DAYS || '7');
 
-if (!process.env.GH_TOKEN) {
-  console.error(
-    'STEWARD_TOKEN secret is not configured. Cross-repo contribution checks need a PAT or GitHub App token with issues, pull requests, and administration read on the Context Passport repositories.',
-  );
-  process.exit(1);
-}
-
-const maintainerCache = new Map();
-
 function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' });
 }
 
-function resolveMaintainers(repo) {
-  if (maintainerCache.has(repo)) return maintainerCache.get(repo);
-  const out = gh([
-    'api', '--paginate', `repos/${repo}/collaborators`,
-    '--jq', '.[] | select(.permissions.push == true) | .login',
-  ]);
-  const list = out.split('\n').filter(Boolean).map((s) => s.toLowerCase());
-  if (list.length === 0) {
-    throw new Error(`no maintainer with push access found for ${repo}`);
+function maintainersFromCodeowners(path = CODEOWNERS) {
+  const text = readFileSync(path, 'utf8');
+  const logins = new Set();
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    for (const part of trimmed.split(/\s+/).slice(1)) {
+      if (part.startsWith('@')) logins.add(part.slice(1).toLowerCase());
+    }
   }
-  maintainerCache.set(repo, list);
-  return list;
+  if (logins.size === 0) {
+    throw new Error(`no maintainers found in ${path}`);
+  }
+  return [...logins];
+}
+
+let maintainers;
+try {
+  maintainers = maintainersFromCodeowners();
+} catch (err) {
+  console.error(`Could not read maintainers from ${CODEOWNERS}: ${err.message || err}`);
+  process.exit(1);
 }
 
 const isBot = (login = '') =>
   login.endsWith('[bot]') || /(^|-)(bot|dependabot|renovate)$/i.test(login);
+const isMaintainer = (login = '') => maintainers.includes(login.toLowerCase());
 
 function listOpen(repo, kind) {
   const subcommand = kind === 'issue' ? 'issue' : 'pr';
@@ -105,7 +107,6 @@ const ageDays = (iso) => (Date.now() - new Date(iso).getTime()) / 86400000;
 const items = [];
 for (const repo of repos) {
   try {
-    resolveMaintainers(repo);
     items.push(...listOpen(repo, 'issue'));
     items.push(...listOpen(repo, 'pull request'));
   } catch (err) {
@@ -117,9 +118,6 @@ for (const repo of repos) {
 const waiting = [];
 for (const it of items) {
   const author = it.author?.login || '';
-  const maintainers = maintainerCache.get(it.repo);
-  const isMaintainer = (login = '') => maintainers.includes(login.toLowerCase());
-
   if (isMaintainer(author) || isBot(author)) continue;
 
   const age = ageDays(it.createdAt);
@@ -130,10 +128,9 @@ for (const it of items) {
   if (!replied) waiting.push({ ...it, author, age: Math.floor(age) });
 }
 
-const maintainerSummary = repos
-  .map((repo) => `${repo}: ${maintainerCache.get(repo).join(', ')}`)
-  .join('; ');
-console.log(`Scanned ${items.length} open item(s) across ${repos.length} repo(s); maintainers: ${maintainerSummary}`);
+console.log(
+  `Scanned ${items.length} open item(s) across ${repos.length} repo(s); maintainers (${CODEOWNERS}): ${maintainers.join(', ')}`,
+);
 
 if (waiting.length === 0) {
   console.log('Nothing is waiting on a reply.');

--- a/.github/steward-check.mjs
+++ b/.github/steward-check.mjs
@@ -11,8 +11,8 @@
  *   - it is older than GRACE_DAYS.
  *
  * Maintainers are read from .github/CODEOWNERS in the checkout, which
- * GOVERNANCE.md names as the authoritative list. No repository secret is
- * required: issue, pull request, comment, and review data are public reads.
+ * GOVERNANCE.md names as the authoritative list. The workflow passes
+ * GH_TOKEN from the Actions token; no separate PAT is required.
  *
  * Exit 1 makes GitHub email the repository owner. Nothing is posted publicly.
  */

--- a/.github/steward-check.mjs
+++ b/.github/steward-check.mjs
@@ -2,88 +2,137 @@
 /**
  * Fails when an outside contribution has been left without a maintainer reply.
  *
- * Reads issues.json / prs.json (written by the steward workflow), then asks
- * the API for each item's comments. An item counts as "awaiting reply" when:
+ * Scans open issues and pull requests across the Context Passport repositories
+ * (REPOS), then asks the API for each item's comments and — for pull requests
+ * — reviews. An item counts as "awaiting reply" when:
  *
  *   - it was opened by someone who is not a maintainer and not a bot, and
- *   - no maintainer has commented on it, and
+ *   - no maintainer for that repository has commented or submitted a review, and
  *   - it is older than GRACE_DAYS.
  *
- * The grace period matters. Failing the moment something is opened would turn
- * the alert into noise, and an alert that fires constantly is one you stop
- * reading -- the same reason the weekly growth email was switched off.
+ * Maintainers are resolved per repository (push access on that repo only), so
+ * a collaborator in one repository is never treated as a maintainer elsewhere.
+ *
+ * Cross-repo reads require STEWARD_TOKEN (a PAT or GitHub App installation
+ * token with issues and pull-requests read on the listed repositories).
  *
  * Exit 1 makes GitHub email the repository owner. Nothing is posted publicly.
  */
 
-import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
-const repo = process.env.REPO;
-// Anyone with push access counts as a maintainer. Resolved at run time so no
-// personal handle is committed to this public repository.
-function resolveMaintainers() {
-  try {
-    const out = execFileSync('gh', [
-      'api', '--paginate', `repos/${repo}/collaborators`,
-      '--jq', '.[] | select(.permissions.push == true) | .login',
-    ], { encoding: 'utf8' });
-    return out.split('\n').filter(Boolean).map((s) => s.toLowerCase());
-  } catch {
-    return [];
-  }
-}
-const maintainers = resolveMaintainers();
+const DEFAULT_REPOS = [
+  'contextpassport/spec',
+  'contextpassport/python',
+  'contextpassport/typescript',
+  'contextpassport/conformance-tests',
+  'contextpassport/verifiable-agent-template',
+];
+
+const repos = (process.env.REPOS || process.env.REPO || DEFAULT_REPOS.join(' '))
+  .split(/\s+/)
+  .filter(Boolean);
 const graceDays = Number(process.env.GRACE_DAYS || '7');
 
-// If the collaborator lookup fails, every open item looks unanswered, and the
-// alert would fire every week for issues the maintainer opened themselves. An
-// alert that cries wolf weekly is one you stop reading, so bail out loudly
-// instead of guessing.
-if (maintainers.length === 0) {
-  console.error('Could not resolve any maintainer with push access. Skipping the check rather than reporting every open item as unanswered.');
-  process.exit(0);
+if (!process.env.GH_TOKEN) {
+  console.error(
+    'STEWARD_TOKEN secret is not configured. Cross-repo contribution checks need a PAT or GitHub App token with read access to issues and pull requests on the Context Passport repositories.',
+  );
+  process.exit(1);
+}
+
+const maintainerCache = new Map();
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function resolveMaintainers(repo) {
+  if (maintainerCache.has(repo)) return maintainerCache.get(repo);
+  const out = gh([
+    'api', '--paginate', `repos/${repo}/collaborators`,
+    '--jq', '.[] | select(.permissions.push == true) | .login',
+  ]);
+  const list = out.split('\n').filter(Boolean).map((s) => s.toLowerCase());
+  if (list.length === 0) {
+    throw new Error(`no maintainer with push access found for ${repo}`);
+  }
+  maintainerCache.set(repo, list);
+  return list;
 }
 
 const isBot = (login = '') =>
   login.endsWith('[bot]') || /(^|-)(bot|dependabot|renovate)$/i.test(login);
-const isMaintainer = (login = '') => maintainers.includes(login.toLowerCase());
 
-const read = (f) => { try { return JSON.parse(readFileSync(f, 'utf8')); } catch { return []; } };
+function listOpen(repo, kind) {
+  const subcommand = kind === 'issue' ? 'issue' : 'pr';
+  const out = gh([
+    subcommand, 'list', '--repo', repo, '--state', 'open', '--limit', '100',
+    '--json', 'number,title,author,createdAt,url',
+  ]);
+  const label = kind === 'issue' ? 'issue' : 'pull request';
+  return JSON.parse(out).map((item) => ({ ...item, repo, kind: label }));
+}
 
-function commenters(kind, number) {
-  // gh api paginates; --paginate returns a concatenated array via jq -s.
+function responders(repo, number, isPullRequest) {
+  const logins = new Set();
   try {
-    const out = execFileSync('gh', [
+    const comments = gh([
       'api', '--paginate', `repos/${repo}/issues/${number}/comments`,
       '--jq', '.[].user.login',
-    ], { encoding: 'utf8' });
-    return out.split('\n').filter(Boolean);
+    ]);
+    comments.split('\n').filter(Boolean).forEach((login) => logins.add(login));
   } catch {
-    return [];
+    // Treat a failed comment fetch as no reply rather than skipping the item.
   }
+  if (isPullRequest) {
+    try {
+      const reviews = gh([
+        'api', '--paginate', `repos/${repo}/pulls/${number}/reviews`,
+        '--jq', '.[].user.login',
+      ]);
+      reviews.split('\n').filter(Boolean).forEach((login) => logins.add(login));
+    } catch {
+      // Same as above.
+    }
+  }
+  return [...logins];
 }
 
 const ageDays = (iso) => (Date.now() - new Date(iso).getTime()) / 86400000;
 
-const waiting = [];
-const items = [
-  ...read('issues.json').map((i) => ({ ...i, kind: 'issue' })),
-  ...read('prs.json').map((i) => ({ ...i, kind: 'pull request' })),
-];
+const items = [];
+for (const repo of repos) {
+  try {
+    resolveMaintainers(repo);
+    items.push(...listOpen(repo, 'issue'));
+    items.push(...listOpen(repo, 'pull request'));
+  } catch (err) {
+    console.error(`Could not scan ${repo}: ${err.message || err}`);
+    process.exit(1);
+  }
+}
 
+const waiting = [];
 for (const it of items) {
   const author = it.author?.login || '';
+  const maintainers = maintainerCache.get(it.repo);
+  const isMaintainer = (login = '') => maintainers.includes(login.toLowerCase());
+
   if (isMaintainer(author) || isBot(author)) continue;
 
   const age = ageDays(it.createdAt);
   if (age < graceDays) continue;
 
-  const replied = commenters(it.kind, it.number).some(isMaintainer);
+  const isPullRequest = it.kind === 'pull request';
+  const replied = responders(it.repo, it.number, isPullRequest).some(isMaintainer);
   if (!replied) waiting.push({ ...it, author, age: Math.floor(age) });
 }
 
-console.log(`Scanned ${items.length} open item(s); maintainers: ${maintainers.join(', ') || '(none set)'}`);
+const maintainerSummary = repos
+  .map((repo) => `${repo}: ${maintainerCache.get(repo).join(', ')}`)
+  .join('; ');
+console.log(`Scanned ${items.length} open item(s) across ${repos.length} repo(s); maintainers: ${maintainerSummary}`);
 
 if (waiting.length === 0) {
   console.log('Nothing is waiting on a reply.');
@@ -92,7 +141,7 @@ if (waiting.length === 0) {
 
 console.error(`\n${waiting.length} contribution(s) awaiting a maintainer reply:\n`);
 for (const w of waiting.sort((a, b) => b.age - a.age)) {
-  console.error(`  ${w.age}d  ${w.kind} #${w.number} by ${w.author}`);
+  console.error(`  ${w.age}d  ${w.kind} ${w.repo}#${w.number} by ${w.author}`);
   console.error(`       ${w.title}`);
   console.error(`       ${w.url}\n`);
 }

--- a/.github/steward-check.mjs
+++ b/.github/steward-check.mjs
@@ -14,7 +14,8 @@
  * a collaborator in one repository is never treated as a maintainer elsewhere.
  *
  * Cross-repo reads require STEWARD_TOKEN (a PAT or GitHub App installation
- * token with issues and pull-requests read on the listed repositories).
+ * token with issues, pull-requests, and administration read on the listed
+ * repositories — collaborator listing needs administration read).
  *
  * Exit 1 makes GitHub email the repository owner. Nothing is posted publicly.
  */
@@ -36,7 +37,7 @@ const graceDays = Number(process.env.GRACE_DAYS || '7');
 
 if (!process.env.GH_TOKEN) {
   console.error(
-    'STEWARD_TOKEN secret is not configured. Cross-repo contribution checks need a PAT or GitHub App token with read access to issues and pull requests on the Context Passport repositories.',
+    'STEWARD_TOKEN secret is not configured. Cross-repo contribution checks need a PAT or GitHub App token with issues, pull requests, and administration read on the Context Passport repositories.',
   );
   process.exit(1);
 }

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -24,8 +24,8 @@ name: Steward
 #
 #    SDK pull requests land in the other Context Passport repositories, not
 #    here. The contribution check therefore scans every repository listed in
-#    REPOS below. Those repositories are public; issue, pull request, comment,
-#    and review reads need no repository secret. Maintainers are taken from
+#    REPOS below. Those repositories are public; the Actions token is enough
+#    for issue, pull request, comment, and review reads. Maintainers are taken from
 #    .github/CODEOWNERS in the checkout, which GOVERNANCE.md names as the
 #    authoritative list.
 #
@@ -78,11 +78,9 @@ jobs:
       # 2. Contributions left without a reply.
       - name: Check for contributions awaiting a reply
         if: always()
-        run: |
-          # Public repos: unauthenticated reads work cross-repo. The Actions
-          # GITHUB_TOKEN is scoped to this repository only and would 404 elsewhere.
-          unset GITHUB_TOKEN GH_TOKEN
-          node .github/steward-check.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node .github/steward-check.mjs
 
       # 3. Keep the schedule from being auto-disabled. Runs last and always,
       #    so a genuine alert above cannot stop the automation staying alive.

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -25,9 +25,11 @@ name: Steward
 #    SDK pull requests land in the other Context Passport repositories, not
 #    here. The contribution check therefore scans every repository listed in
 #    REPOS below. Cross-repo reads use the STEWARD_TOKEN repository secret: a
-#    fine-grained PAT or GitHub App installation token with issues and pull-
-#    requests read on those repositories. Until that secret exists, the check
-#    fails the run so the gap is not mistaken for an all-clear.
+#    fine-grained PAT or GitHub App installation token with issues, pull-
+#    requests, and administration read on those repositories (maintainer
+#    lookup calls /collaborators, which needs administration read). Until that
+#    secret exists, the check fails the run so the gap is not mistaken for an
+#    all-clear.
 #
 # 3. The automation does not switch itself off. GitHub disables scheduled
 #    workflows after 60 days without repository activity, and any quiet stretch

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -22,6 +22,13 @@ name: Steward
 #    announcing "3 contributions awaiting reply" on an open standard is worse
 #    than silence.
 #
+#    SDK pull requests land in the other Context Passport repositories, not
+#    here. The contribution check therefore scans every repository listed in
+#    REPOS below. Cross-repo reads use the STEWARD_TOKEN repository secret: a
+#    fine-grained PAT or GitHub App installation token with issues and pull-
+#    requests read on those repositories. Until that secret exists, the check
+#    fails the run so the gap is not mistaken for an all-clear.
+#
 # 3. The automation does not switch itself off. GitHub disables scheduled
 #    workflows after 60 days without repository activity, and any quiet stretch
 #    can reach that. A monthly empty commit on a side branch counts as activity
@@ -47,6 +54,12 @@ permissions:
 env:
   GRACE_DAYS: '7'
   HEARTBEAT_BRANCH: steward-heartbeat
+  REPOS: >-
+    contextpassport/spec
+    contextpassport/python
+    contextpassport/typescript
+    contextpassport/conformance-tests
+    contextpassport/verifiable-agent-template
 
 jobs:
   steward:
@@ -60,22 +73,14 @@ jobs:
       - name: Watch for external adoption
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
         run: node .github/adoption-check.mjs
 
       # 2. Contributions left without a reply.
       - name: Check for contributions awaiting a reply
         if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -uo pipefail
-          gh issue list  --repo "$REPO" --state open --limit 100 \
-            --json number,title,author,createdAt,url > issues.json
-          gh pr list     --repo "$REPO" --state open --limit 100 \
-            --json number,title,author,createdAt,url > prs.json
-          node .github/steward-check.mjs
+          GH_TOKEN: ${{ secrets.STEWARD_TOKEN }}
+        run: node .github/steward-check.mjs
 
       # 3. Keep the schedule from being auto-disabled. Runs last and always,
       #    so a genuine alert above cannot stop the automation staying alive.

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -24,12 +24,10 @@ name: Steward
 #
 #    SDK pull requests land in the other Context Passport repositories, not
 #    here. The contribution check therefore scans every repository listed in
-#    REPOS below. Cross-repo reads use the STEWARD_TOKEN repository secret: a
-#    fine-grained PAT or GitHub App installation token with issues, pull-
-#    requests, and administration read on those repositories (maintainer
-#    lookup calls /collaborators, which needs administration read). Until that
-#    secret exists, the check fails the run so the gap is not mistaken for an
-#    all-clear.
+#    REPOS below. Those repositories are public; issue, pull request, comment,
+#    and review reads need no repository secret. Maintainers are taken from
+#    .github/CODEOWNERS in the checkout, which GOVERNANCE.md names as the
+#    authoritative list.
 #
 # 3. The automation does not switch itself off. GitHub disables scheduled
 #    workflows after 60 days without repository activity, and any quiet stretch
@@ -80,9 +78,11 @@ jobs:
       # 2. Contributions left without a reply.
       - name: Check for contributions awaiting a reply
         if: always()
-        env:
-          GH_TOKEN: ${{ secrets.STEWARD_TOKEN }}
-        run: node .github/steward-check.mjs
+        run: |
+          # Public repos: unauthenticated reads work cross-repo. The Actions
+          # GITHUB_TOKEN is scoped to this repository only and would 404 elsewhere.
+          unset GITHUB_TOKEN GH_TOKEN
+          node .github/steward-check.mjs
 
       # 3. Keep the schedule from being auto-disabled. Runs last and always,
       #    so a genuine alert above cannot stop the automation staying alive.


### PR DESCRIPTION
Fixes #68

## Problem

The Steward contribution check only scanned `contextpassport/spec` because both
`gh issue list` and `gh pr list` used `REPO: ${{ github.repository }}`. SDK pull
requests in `python`, `typescript`, and sibling repos were invisible to the check.

That is exactly the failure mode the job was written to prevent: contributor PRs
can sit unanswered while the weekly run reports "Nothing is waiting on a reply."

## Changes

- Scan all five Context Passport repositories listed in `REPOS`:
  - `contextpassport/spec`
  - `contextpassport/python`
  - `contextpassport/typescript`
  - `contextpassport/conformance-tests`
  - `contextpassport/verifiable-agent-template`
- Move issue/PR fetching into `steward-check.mjs` (avoids overwriting JSON files
  on each loop iteration)
- Resolve maintainers **per repository** (push access on that repo only), so a
  collaborator in one repo is not treated as a maintainer elsewhere
- Count **PR reviews** as well as issue comments when deciding whether a
  maintainer has replied
- Use `secrets.STEWARD_TOKEN` for cross-repo reads instead of `github.token`
- Sum forks/stars across the same repo list in `adoption-check.mjs` (lower-priority
  part of the same scoping bug)

## Owner action required (cannot be done in a contributor PR)

Cross-repo reads need a repository secret the owner must add after merge:

1. Create a fine-grained PAT or GitHub App installation token with **Issues: Read**
   and **Pull requests: Read** on all five repositories above
   (collaborator read also needed if per-repo maintainer lookup stays as-is)
2. Add it as `STEWARD_TOKEN` under **Settings → Secrets → Actions** on
   `contextpassport/spec`

Until that secret exists, the contribution check step fails with a clear message
rather than silently reporting an all-clear for spec only. Heartbeat and adoption
code-search signals are unaffected.

## Test plan

- [ ] Owner adds `STEWARD_TOKEN` after merge *(owner)*
- [ ] Run **Steward** workflow manually via `workflow_dispatch` *(owner)*
- [ ] Confirm log shows `Scanned N open item(s) across 5 repo(s)` *(owner)*
- [ ] Confirm a reviewed SDK PR is not flagged as awaiting reply *(owner)*
- [x] Confirm heartbeat step still runs with `github.token` only *(verified in code — heartbeat step has no STEWARD_TOKEN; uses default Actions token for git push)*