### PR TITLE
docs: require ECMA-262 full-string match for schema patterns (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,13 @@ breaking, which is exactly what happened in 2.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- SPEC.md: `pattern` constraints in JSON Schema files are now explicitly
+  normative ECMA-262 regex with full-string matching required. Closes the
+  dialect gap where `"commit\n"` accepted in Python `re.match` but rejected
+  by ECMA-262 — a record could otherwise pass one conforming verifier and fail
+  another on the same bytes. No schema or hashed-byte change.
 
 ## [2.0.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ breaking, which is exactly what happened in 2.0.
 ### Changed
 
 - SPEC.md: `pattern` constraints in JSON Schema files are now explicitly
-  normative ECMA-262 regex with full-string matching required. Closes the
-  dialect gap where `"commit\n"` accepted in Python `re.match` but rejected
-  by ECMA-262 — a record could otherwise pass one conforming verifier and fail
-  another on the same bytes. No schema or hashed-byte change.
+  documented as ECMA-262 regex per JSON Schema semantics, including the `$`
+  end-of-string rule that rejects `"commit\n"` in ECMA-262 but accepts it in
+  Python `re.match` / `re.search` — a record could otherwise pass one
+  conforming verifier and fail another on the same bytes. No schema or
+  hashed-byte change.
 
 ## [2.0.1] - 2026-08-28
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -237,6 +237,9 @@ starting with a letter, followed by lowercase letters, digits or underscores,
 joined by single dots. Implementations SHOULD additionally prefix custom types
 with a namespace: `myorg.custom_type`.
 
+Pattern evaluation follows Appendix B. In particular, `"commit\n"` MUST NOT
+match even though some regex dialects (notably Python `re.match`) accept it.
+
 ### 3.4 Integrity computation
 
 Implementations MUST compute the integrity block as follows:
@@ -321,7 +324,7 @@ the parent, never the filename.
 
 An implementation is **Context Passport v2.0 conformant** if it:
 
-1. Produces passports that validate against the JSON Schema at `schema/v2.json`.
+1. Produces passports that validate against the JSON Schema at `schema/v2.json`, including `pattern` constraints evaluated per Appendix B.
 2. Correctly computes the integrity block per section 3.4 using RFC 8785 (JCS).
 3. Correctly links parent commits via `parent_id`.
 4. Correctly verifies chains by recomputing hashes. For mixed-version chains, dispatches per-record on `schema_version` (v1.x records use the v1.x algorithm; v2.x records use JCS).
@@ -516,6 +519,15 @@ The machine-readable JSON Schemas are in this repository:
 
 - `schema/v2.json` — current specification (v2.0)
 - `schema/v1.json` — retained for verifying v1.x records via the compatibility shim
+
+Every `pattern` constraint in these schemas uses ECMA-262 regular expression
+syntax, per the JSON Schema specification. Implementations MUST evaluate each
+pattern as a full-string match equivalent to ECMA-262
+`RegExp.prototype.test` on the entire string value. In regex dialects where
+`^` and `$` behave differently — notably Python's `re` module, where `$`
+matches immediately before a trailing newline — implementations MUST NOT use
+partial matchers such as `re.match` or `re.search`; use `re.fullmatch` or
+equivalent instead.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -521,13 +521,11 @@ The machine-readable JSON Schemas are in this repository:
 - `schema/v1.json` — retained for verifying v1.x records via the compatibility shim
 
 Every `pattern` constraint in these schemas uses ECMA-262 regular expression
-syntax, per the JSON Schema specification. Implementations MUST evaluate each
-pattern as a full-string match equivalent to ECMA-262
-`RegExp.prototype.test` on the entire string value. In regex dialects where
-`^` and `$` behave differently — notably Python's `re` module, where `$`
-matches immediately before a trailing newline — implementations MUST NOT use
-partial matchers such as `re.match` or `re.search`; use `re.fullmatch` or
-equivalent instead.
+syntax and semantics, per the JSON Schema specification. In particular `$`
+matches only at the end of the string, never before a trailing newline.
+Python's `re` module differs here, so implementations MUST NOT evaluate these
+patterns with `re.match` or `re.search`; `re.fullmatch` gives the correct
+result for the anchored patterns in these schemas.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #51.

Documents that every `pattern` constraint in the JSON Schema files uses ECMA-262 regular expression syntax and MUST be evaluated as a full-string match. This closes a cross-language verification gap where `"commit\n"` was accepted by Python `re.match` / plain `jsonschema` but rejected by ECMA-262 (`RegExp.test`, ajv).

No change to `schema/v2.json` or any hashed bytes — prose clarification only (Option 2 from the issue).

## Problem

`event.type` is constrained by: ^[a-z][a-z0-9_](.[a-z][a-z0-9_])*$


JSON Schema defines `pattern` as ECMA-262 regex. In that dialect, `$` matches only the true end of the string, so `"commit\n"` is **rejected**. Python's `re` module treats `$` as matching immediately before a trailing newline, so `re.match` / `re.search` **accept** the same value.

Two conforming-looking verifiers can therefore reach opposite verdicts on the same record — a real tamper-evidence hole for a format whose value proposition is offline, cross-implementation verification.

## Changes

- **SPEC.md §3.3** — worked example: `"commit\n"` MUST NOT match; points to Appendix B
- **SPEC.md §4** — conformance clause 1 references Appendix B for `pattern` evaluation
- **SPEC.md Appendix B** — normative rule: ECMA-262 syntax; full-string match required (`RegExp.prototype.test` / `re.fullmatch`, not `re.match`/`re.search`)
- **CHANGELOG.md** — Unreleased entry

## What this does NOT change

- The regex in `schema/v2.json` is unchanged
- No schema version bump; no breaking change to existing valid records

## Follow-up (separate PRs, after this lands)

- [ ] Merge `contextpassport/python#11` (`re.fullmatch` for event type validation)
- [ ] Consolidate related Python PRs (#10, #14) if still open
- [ ] Verify `contextpassport/typescript#8` / `#9` (JS is already correct on `$` semantics)
- [ ] Add conformance vector in `contextpassport/conformance-tests#14`: `event.type = "commit\n"` → invalid

## Test plan

- [x] Repro verified locally:
  - JS: `new RegExp("^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$").test("commit\n")` → `false`
  - Python: `re.fullmatch(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$", "commit\n")` → `None`
- [ ] No schema or example file changes; existing CI should pass unchanged
