### PR TITLE
ci: parse the automation scripts, which CI never loaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,38 @@ jobs:
       # so it cannot come back quietly.
       - run: node tools/check-server.mjs
 
+  scripts:
+    name: Automation scripts parse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+      # Nothing in CI ever loaded .github/*.mjs, so a change that stopped one
+      # of them parsing went green three times in a row on #69. The Steward
+      # scripts only run on a schedule, where the first sign of trouble is a
+      # failure email a week later that reads like the adoption alert it was
+      # meant to send.
+      #
+      # This only proves the files parse. It does not prove they work, and it
+      # is not a substitute for running them. It is here because the specific
+      # way #69 broke, a `*/` inside a block comment closing it early, is
+      # invisible on review and free to catch.
+      # Check every file and report all failures, rather than stopping at the
+      # first one, so a run names everything that needs fixing.
+      - run: |
+          failed=0
+          for f in .github/*.mjs tools/*.mjs; do
+            if node --check "$f"; then
+              echo "ok    $f"
+            else
+              echo "FAIL  $f"
+              failed=1
+            fi
+          done
+          exit $failed
+
   docs-and-examples:
     name: Documented code still runs
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The gap

Spec CI validates the examples, the server, and both quickstarts. It never loads `.github/adoption-check.mjs` or `.github/steward-check.mjs`. Those two run only on the Monday schedule, so nothing in the pipeline notices when one of them stops being valid JavaScript.

## How it showed up

#69 rewrote a comment line in `adoption-check.mjs`:

```
 *   forks_*/stars_* per repository. Weaker than a code hit, but a fork is a
```

The `*/` closes the block comment 20 lines early, and the file stops parsing:

```
$ node --check .github/adoption-check.mjs
.github/adoption-check.mjs:29
 *   forks_*/stars_* per repository. Weaker than a code hit, but a fork is a
                         ^^^^^^^^^^
SyntaxError: Unexpected identifier 'repository'
```

Spec CI went green on that branch three times, and I confirmed it on a runner: the adoption step exits 1 with the SyntaxError above and checks nothing.

That failure mode is worse than it sounds. The adoption check is the one alert in this project designed to fire rarely and be believed, and a red Steward run is exactly how a genuine signal announces itself. A crash and a real adoption rise look the same in the inbox.

## The change

One job, `Automation scripts parse`, running `node --check` over `.github/*.mjs` and `tools/*.mjs`. It checks every file and reports all failures rather than stopping at the first, so a run names everything that needs fixing.

Verified against both trees:

```
main                          exit 0
  ok    .github/adoption-check.mjs
  ok    .github/steward-check.mjs
  ok    tools/check-published-schema.mjs
  ok    tools/check-quickstart-ts.mjs
  ok    tools/check-server.mjs
  ok    tools/validate-examples.mjs

with #69's adoption-check.mjs   exit 1
  FAIL  .github/adoption-check.mjs
  ok    (the other five)
```

## What this does not do

It proves the files parse. It does not prove they work. Running the Steward scripts for real needs a token and live API calls against five repositories, which is a separate question and a slower, flakier job. This catches the specific class of breakage that is invisible on review and free to check.

CI and tooling only, no normative content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjkUXJE8tTXxnjMtP1WhML

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjkUXJE8tTXxnjMtP1WhML)_