### PR TITLE
fix: npm install alone should be enough to run the quickstart check

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "serve": "^14.0.0"
   },
   "devDependencies": {
+    "@contextpassport/core": "^2.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "canonicalize": "^2.0.0"
+    "canonicalize": "^2.0.0",
+    "tsx": "^4.0.0"
   }
 }

--- a/tools/check-quickstart-ts.mjs
+++ b/tools/check-quickstart-ts.mjs
@@ -48,12 +48,27 @@ try {
 
 if (result.error) {
   console.error(String(result.error));
-  console.error("Is tsx installed? CI does: npm install --no-save @contextpassport/core@^2.0.0 tsx");
+  console.error("Is tsx installed? Run npm install, or: npm install --no-save @contextpassport/core@^2.0.0 tsx");
   process.exit(1);
 }
+// A missing tsx or SDK surfaces here rather than as result.error: node itself
+// launches fine and the child exits non-zero when it cannot resolve the
+// import. Blaming the document for that is wrong and sends the reader off to
+// debug prose that is not broken.
 if (result.status !== 0) {
+  const stderr = result.stderr ?? "";
+  const missing = stderr.match(/Cannot find package '([^']+)'/);
+  if (missing) {
+    console.error(stderr);
+    console.error(
+      `Cannot resolve '${missing[1]}', so the quickstart was never run. This is a ` +
+        `missing dependency here, not a problem with the document.`,
+    );
+    console.error("Run npm install, or: npm install --no-save @contextpassport/core@^2.0.0 tsx");
+    process.exit(1);
+  }
   console.log(result.stdout);
-  console.error(result.stderr);
+  console.error(stderr);
   console.error("docs/quickstart-typescript.md does not run as written");
   process.exit(1);
 }


### PR DESCRIPTION
## The problem

`tools/check-quickstart-ts.mjs` needs `tsx` and `@contextpassport/core`, and neither was declared anywhere in `package.json`. CI gets away with it because the `docs-and-examples` job installs both explicitly:

```yaml
- run: npm install --no-save @contextpassport/core@^2.0.0 tsx
```

So the gap only ever appears for somebody working locally, which is to say a contributor.

What they see is worse than a plain missing package. The tool already anticipates this case and prints a helpful line about installing `tsx`, but only on the `result.error` branch, which fires when `spawnSync` cannot launch the process at all. A missing `tsx` does not do that. Node starts fine, and the child exits non-zero when it cannot resolve the import, so control reaches the status check instead. That branch dumps a raw stack and concludes:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsx' imported from /home/user/spec/
    ... 10 more lines of stack ...

docs/quickstart-typescript.md does not run as written
```

The document is fine. The reader is now debugging prose that was never executed, which is the most expensive possible way to find out you are missing a dev dependency. For a repo whose whole pitch is that the documentation demonstrably runs, a false "the docs are broken" is a bad first impression to hand a new contributor.

## The change

Declare both packages in `devDependencies`, so `npm install` is sufficient, and detect an unresolved import in the status branch and say so plainly instead of blaming the document.

`devDependencies` rather than `dependencies` because both are used only by the tools, not by the served site.

## CI is unaffected

The `docs-and-examples` job never runs a plain `npm install`. It installs what it needs with `--no-save` and continues to do so, so this changes nothing about how CI resolves either package. The change only makes the local path work.

## Verified on this branch

With `node_modules` removed, the diagnostic is now honest about the cause:

```
Cannot resolve 'tsx', so the quickstart was never run. This is a missing
dependency here, not a problem with the document.
Run npm install, or: npm install --no-save @contextpassport/core@^2.0.0 tsx
```

After a plain `npm install`, with no extra flags, all four checks pass:

```
$ node tools/check-quickstart-ts.mjs
docs/quickstart-typescript.md runs as written: 5 blocks, results as documented.

$ python3 tools/check-quickstart.py
docs/quickstart.md runs as written: 5 blocks, results as documented.

$ npm test
All examples valid: schema, recomputed hashes, and chain linkage.
server.js serves the site root and nothing outside it.
```

No lock file is added, since the repo does not track one.

Found during the daily triage sweep. Touches tooling only, no normative text and no hashed bytes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPy4TEXwb6EqnZSGJKT1Nn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPy4TEXwb6EqnZSGJKT1Nn)_