### PR TITLE
fix: the Steward does not watch tinker-provenance

### DIFF
--- a/.github/adoption-check.mjs
+++ b/.github/adoption-check.mjs
@@ -53,6 +53,7 @@ const DEFAULT_REPOS = [
   'contextpassport/typescript',
   'contextpassport/conformance-tests',
   'contextpassport/verifiable-agent-template',
+  'contextpassport/tinker-provenance',
 ];
 const repos = (process.env.REPOS || process.env.REPO || DEFAULT_REPOS.join(' '))
   .split(/\s+/)

--- a/.github/adoption.json
+++ b/.github/adoption.json
@@ -14,6 +14,8 @@
     "forks_conformance-tests": 0,
     "stars_conformance-tests": 0,
     "forks_verifiable-agent-template": 0,
-    "stars_verifiable-agent-template": 0
+    "stars_verifiable-agent-template": 0,
+    "forks_tinker-provenance": 0,
+    "stars_tinker-provenance": 0
   }
 }

--- a/.github/steward-check.mjs
+++ b/.github/steward-check.mjs
@@ -26,6 +26,7 @@ const DEFAULT_REPOS = [
   'contextpassport/typescript',
   'contextpassport/conformance-tests',
   'contextpassport/verifiable-agent-template',
+  'contextpassport/tinker-provenance',
 ];
 
 const CODEOWNERS = '.github/CODEOWNERS';


### PR DESCRIPTION
Both automation scripts carry a hardcoded `DEFAULT_REPOS` list of five repositories. `contextpassport/tinker-provenance` was created on 29 August and was never added, so for the last week it has been invisible to both checks.

## Why this matters

The contribution check is the half that matters. Its whole job is to notice an outside contributor waiting on a reply, and an issue or pull request opened on `tinker-provenance` would not have been counted at all. That is the same failure #68 described for `python` and `typescript`, recurring for a repository created after that fix landed.

Adoption is the cheaper half: forks and stars on that repository were neither baselined nor watched.

## The change

Adds the repository to both `DEFAULT_REPOS` lists and seeds its baseline at the values the API reports today, forks 0 and stars 0.

Seeding is not strictly required. `adoption-check.mjs` only alarms when `before[k] !== undefined && v > before[k]`, so a key absent from the baseline is recorded rather than alarmed on. Writing it explicitly matches the per-repo pattern from 5cd8e7a and keeps the file readable as a list of what is being watched.

## Verified on this branch

```
node --check over .github/*.mjs and tools/*.mjs   all six ok
adoption.json parses, 17 signals, tinker at 0/0
both DEFAULT_REPOS lists agree, six repositories each

npm test
  All examples valid: schema, recomputed hashes, and chain linkage.
  server.js serves the site root and nothing outside it.

python3 tools/check-quickstart.py
  docs/quickstart.md runs as written: 5 blocks, results as documented.

node tools/check-quickstart-ts.mjs
  docs/quickstart-typescript.md runs as written: 5 blocks, results as documented.
```

## What is deliberately not in this change

`contextpassport/conformance` is not added. It is an empty repository with no commits since it was created in May, and it duplicates `conformance-tests` by name. Whether it should be watched or removed is a question for the owner rather than something to settle by wiring it in here.

The list stays hardcoded. Auto discovery from the org would make this class of gap impossible, but it would also pull in empty and future repositories without review, and the baseline would churn as repositories come and go. If this drifts a third time that trade is worth revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzAtNVuLVHFPG8efaH8VP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzAtNVuLVHFPG8efaH8VP1)_