### PR TITLE
Publish array schema so chains get editor support (#66)

### DIFF
--- a/.github/workflows/published-schema.yml
+++ b/.github/workflows/published-schema.yml
@@ -1,15 +1,16 @@
 name: Published schema
 
-# Watches the schema actually served at contextpassport.com, which SchemaStore
+# Watches the schemas actually served at contextpassport.com, which SchemaStore
 # has pointed every VS Code, Visual Studio and JetBrains install at since
-# SchemaStore/schemastore#6264 merged on 28 August 2026.
+# SchemaStore/schemastore#6264 merged on 28 August 2026 (singular *.passport.json,
+# and the chain schema for *.passports.json once that catalog entry lands).
 #
 # Deliberately not on push or pull_request. A pull request that edits
-# schema/v2.json would fail this check for the honest reason that the site has
-# not been redeployed yet, and a check that cries wolf on correct work is a
-# check people learn to ignore. The risk here is drift over time and the site
-# going down, neither of which is caused by a commit, so a daily schedule
-# catches it and a push trigger would not.
+# schema/v2.json or schema/v2-chain.json would fail this check for the honest
+# reason that the site has not been redeployed yet, and a check that cries wolf
+# on correct work is a check people learn to ignore. The risk here is drift over
+# time and the site going down, neither of which is caused by a commit, so a
+# daily schedule catches it and a push trigger would not.
 
 on:
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ breaking, which is exactly what happened in 2.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- `schema/v2-chain.json`: JSON Schema for an array of one or more v2 records,
+  so SchemaStore (and editors that consult it) can validate `*.passports.json`
+  chain files the same way `*.passport.json` already maps to `schema/v2.json`
+  (#66). Shape only — linkage still needs a hash walk.
 
 ## [2.0.1] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The goal: become the standard envelope format for AI agent events — a record a
 - [`docs/quickstart.md`](docs/quickstart.md) — five minutes from install to a verified chain
 - [`docs/quickstart-typescript.md`](docs/quickstart-typescript.md) — the same quickstart for the TypeScript SDK
 - [`SPEC.md`](SPEC.md) — full specification (v2.0)
-- [`schema/v2.json`](schema/v2.json) — machine-readable JSON Schema (v2.0)
+- [`schema/v2.json`](schema/v2.json) — machine-readable JSON Schema (v2.0, single record)
+- [`schema/v2-chain.json`](schema/v2-chain.json) — array of v2 records (`*.passports.json` chains)
 - [`schema/v1.json`](schema/v1.json) — machine-readable JSON Schema (v1.x, retained for compatibility)
 - [`docs/`](docs/) — non-normative design notes for implementers
   - [`throughput-and-trust.md`](docs/throughput-and-trust.md) — submission patterns, trust properties, SDK guidance

--- a/SPEC.md
+++ b/SPEC.md
@@ -514,7 +514,8 @@ def verify_chain(passports):
 
 The machine-readable JSON Schemas are in this repository:
 
-- `schema/v2.json` — current specification (v2.0)
+- `schema/v2.json` — current specification (v2.0), single record
+- `schema/v2-chain.json` — array of v2 records (the `*.passports.json` chain shape)
 - `schema/v1.json` — retained for verifying v1.x records via the compatibility shim
 
 ---

--- a/schema/v2-chain.json
+++ b/schema/v2-chain.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://contextpassport.com/schema/v2-chain.json",
+  "title": "Context Passport Chain (v2)",
+  "description": "An array of one or more Context Passport v2 records. This schema only validates that each element is individually well-formed; it cannot express the chain's linkage invariant (each record's parent_hash must equal the previous record's integrity_hash). A file validating against this schema is a well-formed list of records, not a verified chain — verification requires walking the hashes with a validator, not just a green tick from an editor.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "$ref": "https://contextpassport.com/schema/v2.json"
+  }
+}

--- a/tools/check-published-schema.mjs
+++ b/tools/check-published-schema.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * Asserts that the schema served at contextpassport.com is the schema in this
- * repository.
+ * Asserts that the schemas served at contextpassport.com match the schemas in
+ * this repository.
  *
- * That URL stopped being a convenience on 28 August 2026, when SchemaStore
- * merged a catalog entry pointing at it (SchemaStore/schemastore#6264). Every
- * VS Code, Visual Studio and JetBrains install now fetches it whenever someone
- * opens a *.passport.json file. Nobody who hits a stale or missing copy will
- * know to tell us: they will see validation errors on a valid document, blame
- * the format, and close the file.
+ * Those URLs stopped being a convenience on 28 August 2026, when SchemaStore
+ * merged a catalog entry pointing at the singular schema
+ * (SchemaStore/schemastore#6264). Every VS Code, Visual Studio and JetBrains
+ * install now fetches it whenever someone opens a *.passport.json file. The
+ * chain schema is the matching entry for *.passports.json. Nobody who hits a
+ * stale or missing copy will know to tell us: they will see validation errors
+ * on a valid document, blame the format, and close the file.
  *
  * The failure this guards is silent by construction. A deploy that does not
  * happen leaves the repository correct and the world wrong, so nothing in the
@@ -24,8 +25,27 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const LOCAL = join(ROOT, 'schema', 'v2.json');
-const PUBLISHED = 'https://contextpassport.com/schema/v2.json';
+
+const SCHEMAS = [
+  {
+    local: join(ROOT, 'schema', 'v2.json'),
+    published: 'https://contextpassport.com/schema/v2.json',
+    label: 'schema/v2.json',
+    downHint: [
+      'SchemaStore points editors at this URL. While it is down, every',
+      '*.passport.json file in every IDE fails to validate.',
+    ],
+  },
+  {
+    local: join(ROOT, 'schema', 'v2-chain.json'),
+    published: 'https://contextpassport.com/schema/v2-chain.json',
+    label: 'schema/v2-chain.json',
+    downHint: [
+      'This URL is the SchemaStore target for *.passports.json. While it is',
+      'down, every chain file in every IDE fails to validate.',
+    ],
+  },
+];
 
 // Compare canonically so key order in the served file cannot raise a false
 // alarm. What matters is that the two describe the same constraints.
@@ -37,20 +57,19 @@ const canon = (v) =>
   );
 
 /**
- * Returns an array of failure strings. Empty means the published schema is
- * good. Never calls process.exit: exiting hard while an undici keep-alive
- * socket is open aborts the process with a libuv assertion on Windows, which
- * surfaces as exit 127 and a C-level stack trace instead of the readable
- * failure this file exists to produce.
+ * Returns an array of failure strings for one schema. Empty means the
+ * published copy is good. Never calls process.exit: exiting hard while an
+ * undici keep-alive socket is open aborts the process with a libuv assertion
+ * on Windows, which surfaces as exit 127 and a C-level stack trace instead of
+ * the readable failure this file exists to produce.
  */
-async function check() {
-  const res = await fetch(PUBLISHED, { headers: { accept: 'application/json' } });
+async function checkOne({ local, published, label, downHint }) {
+  const res = await fetch(published, { headers: { accept: 'application/json' } });
 
   if (res.status !== 200) {
     return [
-      `${PUBLISHED} returned ${res.status} ${res.statusText}`,
-      'SchemaStore points editors at this URL. While it is down, every',
-      '*.passport.json file in every IDE fails to validate.',
+      `${published} returned ${res.status} ${res.statusText}`,
+      ...downHint,
     ];
   }
 
@@ -61,31 +80,31 @@ async function check() {
   const ctype = (res.headers.get('content-type') ?? '').split(';')[0].trim();
   const body = await res.text();
 
-  let published;
+  let publishedBody;
   try {
-    published = JSON.parse(body);
+    publishedBody = JSON.parse(body);
   } catch (e) {
     return [
-      `the published schema is not valid JSON: ${e.message}`,
+      `the published ${label} is not valid JSON: ${e.message}`,
       `first 200 bytes: ${body.slice(0, 200)}`,
     ];
   }
 
-  const local = JSON.parse(readFileSync(LOCAL, 'utf8'));
+  const localBody = JSON.parse(readFileSync(local, 'utf8'));
   const problems = [];
 
   if (ctype !== 'application/json') {
     problems.push(`content-type is "${ctype}", expected "application/json"`);
   }
 
-  if (canon(published) !== canon(local)) {
-    problems.push('the published schema differs from schema/v2.json');
-    const pk = Object.keys(published);
-    const lk = Object.keys(local);
+  if (canon(publishedBody) !== canon(localBody)) {
+    problems.push(`the published schema differs from ${label}`);
+    const pk = Object.keys(publishedBody);
+    const lk = Object.keys(localBody);
     for (const k of pk.filter((k) => !lk.includes(k))) problems.push(`  only published: ${k}`);
     for (const k of lk.filter((k) => !pk.includes(k))) problems.push(`  only in repo:   ${k}`);
     for (const k of pk.filter((k) => lk.includes(k))) {
-      if (canon(published[k]) !== canon(local[k])) problems.push(`  differs:        ${k}`);
+      if (canon(publishedBody[k]) !== canon(localBody[k])) problems.push(`  differs:        ${k}`);
     }
     problems.push("  The site needs redeploying, or the repo needs the site's version.");
   }
@@ -93,17 +112,21 @@ async function check() {
   // A schema whose $id disagrees with where it is served from resolves any
   // future $ref against the wrong base, and tells a reader it came from
   // somewhere else.
-  if (published.$id !== PUBLISHED) {
-    problems.push(`$id is "${published.$id}", expected "${PUBLISHED}"`);
+  if (publishedBody.$id !== published) {
+    problems.push(`$id is "${publishedBody.$id}", expected "${published}"`);
   }
 
   if (problems.length === 0) {
-    console.log(`Published schema matches schema/v2.json (${body.length} bytes, ${ctype}, $id ok).`);
+    console.log(`Published schema matches ${label} (${body.length} bytes, ${ctype}, $id ok).`);
   }
   return problems;
 }
 
-const problems = await check();
+const problems = [];
+for (const schema of SCHEMAS) {
+  problems.push(...await checkOne(schema));
+}
+
 if (problems.length > 0) {
   for (const p of problems) console.error(p.startsWith(' ') ? p : `FAIL  ${p}`);
   console.error('\nSchemaStore catalog: https://www.schemastore.org/api/json/catalog.json');

--- a/tools/check-server.mjs
+++ b/tools/check-server.mjs
@@ -77,6 +77,13 @@ try {
     fail('did not serve /schema/v2.json');
   }
 
+  const chain = await rawRequest('/schema/v2-chain.json');
+  if (chain.startsWith('HTTP/1.1 200') && chain.includes('"$id"') && chain.includes('contextpassport.com/schema/v2-chain.json')) {
+    pass('serves /schema/v2-chain.json');
+  } else {
+    fail('did not serve /schema/v2-chain.json');
+  }
+
   const index = await rawRequest('/');
   if (index.startsWith('HTTP/1.1 200') && index.includes('text/html')) {
     pass('serves / as html');

--- a/tools/validate-examples.mjs
+++ b/tools/validate-examples.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
- * Validates every file in examples/ against schema/v2.json, and, more
- * importantly, recomputes the integrity block from the payload rather than
- * trusting the hashes that are written in the file.
+ * Validates every file in examples/ against schema/v2.json (and chain files
+ * against schema/v2-chain.json), and, more importantly, recomputes the
+ * integrity block from the payload rather than trusting the hashes that are
+ * written in the file.
  *
  * Shape validation alone is close to worthless for this spec. A record can
  * satisfy every constraint in the JSON Schema (all fields present, every hash
@@ -20,6 +21,10 @@
  * and for array examples, walks the chain checking that each parent_hash is
  * the previous record's integrity_hash.
  *
+ * The chain schema is preloaded with the local record schema so Ajv resolves
+ * the published $ref without a network fetch. CI stays hermetic; online
+ * editors still fetch https://contextpassport.com/schema/v2.json.
+ *
  * Run: node tools/validate-examples.mjs
  */
 
@@ -35,9 +40,12 @@ const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const sha256 = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
 
 const schema = JSON.parse(readFileSync(join(root, 'schema/v2.json'), 'utf8'));
+const chainSchema = JSON.parse(readFileSync(join(root, 'schema/v2-chain.json'), 'utf8'));
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
+ajv.addSchema(schema);
 const validate = ajv.compile(schema);
+const validateChain = ajv.compile(chainSchema);
 
 let failures = 0;
 const fail = (file, msg) => { failures++; console.error(`  FAIL  ${file}: ${msg}`); };
@@ -81,12 +89,22 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-console.log(`\n  Context Passport, validating ${files.length} example file(s) against schema/v2.json\n`);
+console.log(`\n  Context Passport, validating ${files.length} example file(s) against schema/v2.json and schema/v2-chain.json\n`);
+
+let chainCount = 0;
+let recordCount = 0;
 
 for (const f of files) {
   const raw = JSON.parse(readFileSync(join(root, 'examples', f), 'utf8'));
 
   if (Array.isArray(raw)) {
+    chainCount++;
+    if (!validateChain(raw)) {
+      for (const e of validateChain.errors) {
+        fail(f, `chain schema: ${e.instancePath || '/'} ${e.message}`);
+      }
+    }
+
     let prev = null;
     raw.forEach((rec, i) => {
       const ok = checkRecord(f, rec, `${i}`);
@@ -104,13 +122,27 @@ for (const f of files) {
     });
     console.log(`  checked  ${f}  (chain of ${raw.length})`);
   } else {
+    recordCount++;
+    // A lone object must not satisfy the chain schema. Asserting that keeps
+    // the two file shapes distinct for SchemaStore consumers.
+    if (validateChain(raw)) {
+      fail(f, 'lone record unexpectedly validates against schema/v2-chain.json');
+    }
+
     checkRecord(f, raw, null);
     console.log(`  checked  ${f}`);
   }
+}
+
+if (chainCount === 0) {
+  fail('(suite)', 'no *.passports.json chain examples found to exercise schema/v2-chain.json');
+}
+if (recordCount === 0) {
+  fail('(suite)', 'no *.passport.json record examples found');
 }
 
 if (failures) {
   console.error(`\n  ${failures} problem(s) found.\n`);
   process.exit(1);
 }
-console.log('\n  All examples valid: schema, recomputed hashes, and chain linkage.\n');
+console.log(`\n  All examples valid: schema, chain schema (${chainCount} accepted, ${recordCount} rejected), recomputed hashes, and chain linkage.\n`);


### PR DESCRIPTION
## Summary

SchemaStore already points editors at `schema/v2.json` for `*.passport.json`. The plural form (`*.passports.json`) was left unregistered on purpose: pointing an array of records at an object schema would mark every valid chain invalid.

This adds the missing artifact — `schema/v2-chain.json` — so a follow-up SchemaStore catalog entry can register `*.passports.json` without that footgun.

- New schema: `type: array`, `minItems: 1`, `items.$ref` → `https://contextpassport.com/schema/v2.json`
- `$id` matches the served URL: `https://contextpassport.com/schema/v2-chain.json`
- Description documents that JSON Schema cannot express hash-chain linkage; a green tick is shape-only, not verification
- `tools/validate-examples.mjs` asserts six chain examples accept and eleven single-record examples reject
- `tools/check-published-schema.mjs` generalized to check both published schemas
- `tools/check-server.mjs` asserts `/schema/v2-chain.json` is served as JSON

Decisions (from #66): filename `v2-chain` (spec vocabulary), `$ref` over inline (one source of truth), `minItems: 1`.

## Test plan

- [x] `npm test` — 6 `*.passports.json` validate against `v2-chain`; 11 `*.passport.json` are rejected by it
- [x] Local server serves `/schema/v2-chain.json` with matching `$id`
- [ ] After merge: deploy site so `https://contextpassport.com/schema/v2-chain.json` is live (`application/json`)
- [ ] After deploy: scheduled `check-published-schema` passes for both URLs
- [ ] Follow-up: SchemaStore PR registering `*.passports.json` → the new URL (closes the commitment in SchemaStore/schemastore#6264)

Closes #66