### PR TITLE
fix: the adoption alert fired on a stranger's unrelated project

### DIFF
--- a/.github/adoption-check.mjs
+++ b/.github/adoption-check.mjs
@@ -19,7 +19,18 @@
  *                not usage. That false positive was live for one run, caused by
  *                our own SchemaStore entry being merged.
  *   python / ts  someone imported a reference SDK in a public repo.
- *   mcp          someone wired up the DarkMatter MCP tools.
+ *   mcp          someone installed the DarkMatter MCP server, which emits
+ *                passports. This searched for "darkmatter_commit" until
+ *                2026-09-05, when it reported FIRST EXTERNAL USE DETECTED on
+ *                four hits in dadukhankevin/DarkMatter. All four were
+ *                "darkmatter_commitment", a different tool in an unrelated
+ *                p2p messaging project that shares the DarkMatter name and
+ *                uses "passport" for its own identity concept. That repo has
+ *                no reference to Context Passport at all. A tool name is not
+ *                ours to own; a package name is, so this now searches for the
+ *                package. The lesson is the rule already stated below: if a
+ *                stranger can trip a signal without using this format, the
+ *                signal is measuring something else.
  *   tinker       someone recorded a fine-tuning run. The namespaced event type
  *                is what makes this findable: a generic "commit" is
  *                indistinguishable from every other passport in the world,
@@ -66,7 +77,7 @@ const CODE_QUERIES = {
   records: '"contextpassport.com/schema" "integrity_hash"',
   python: '"from context_passport import"',
   typescript: '"@contextpassport/core"',
-  mcp: '"darkmatter_commit"',
+  mcp: '"@darkmatterhub/mcp-server"',
   tinker: '"tinker.finetune_started"',
 };
 


### PR DESCRIPTION
The Steward failed twice today with the alert this project exists to receive:

```
FIRST EXTERNAL USE DETECTED
  mcp: 4 hit(s) where there were none
    dadukhankevin/DarkMatter
```

It is wrong, and two coincidences stacked to produce it.

**The query matched a different word.** `mcp` searched for `"darkmatter_commit"`. All four hits are `darkmatter_commitment`, matched on prefix by GitHub's tokenizer. Different tool, different purpose.

**The repo is a different DarkMatter.** `dadukhankevin/DarkMatter` is a p2p agent-messaging project, 18 stars, unrelated to `darkmatter-hub`. It uses the word "passport" for its own network identity concept, which makes it look even more like a hit than it is. Searched it directly:

| query | hits |
|---|---|
| `contextpassport` | 0 |
| `"context passport"` | 0 |
| `integrity_hash` | 0 |
| `"schema_version" "2.0"` | 0 |

## Why acknowledging would have been worse than the alarm

The baseline is a floor. Committing `mcp: 4` means a genuine first use needs **five** hits before it alarms. The single alert this whole mechanism exists to deliver would have been quietly raised out of reach by a stranger who has never heard of this project.

## The fix

Search `"@darkmatterhub/mcp-server"` instead. A tool name is not ours to own and a stranger can collide with it. A scoped package name cannot be tripped by anyone who has not installed it. Returns 0 today.

This is the rule the comment above `CODE_QUERIES` already states:

> Queries chosen to be specific enough that a hit is real.

`mcp` was the only entry breaking it. The other four match this format's own identifiers. Recorded in the signal notes alongside the existing SchemaStore false positive, because the pattern generalises: if a stranger can trip a signal without using the format, the signal is measuring something else.

## Verified

```
$ node .github/adoption-check.mjs
No change.
exit=0
```

Baseline file untouched, so nothing needs acknowledging and the weekly alert stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)