### PR TITLE
fix: return 404 for missing paths instead of the index page

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,23 +92,37 @@ http.createServer((req, res) => {
     });
   };
 
-  const serveIndex = () => {
-    // Fallback to root index.html for SPA-style routing of unknown paths
-    fs.readFile(path.join(ROOT, 'index.html'), (err2, data2) => {
-      if (err2) { res.writeHead(404); res.end('Not found'); return; }
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(data2);
-    });
+  // A miss is a 404, not the index page.
+  //
+  // This used to fall through to index.html for SPA-style routing. Nothing on
+  // this site routes on the client, so there was no route being rescued: the
+  // only internal links are /, /blog/ and a real file under /blog/, and each
+  // of those resolves to something on disk. What the fallback did instead was
+  // answer every mistyped, renamed or not-yet-deployed path with "200, here
+  // is a document".
+  //
+  // That became expensive when SchemaStore/schemastore#6264 merged, because
+  // editors now fetch /schema/*.json on their own without the user asking. A
+  // 404 tells a validator the schema is not there. A 200 of HTML tells it the
+  // schema arrived, so the JSON parse error surfaces against the user's own
+  // document rather than against the URL, and the person seeing it has no
+  // path back to the cause.
+  //
+  // text/plain rather than an HTML error page, so nothing reading the
+  // content-type is told it was handed a document to parse.
+  const serveNotFound = () => {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not found\n');
   };
 
   const filePath = resolveWithinRoot(urlPath);
 
   // A path pointing outside the root is treated as a miss rather than as its
-  // own status code. It gets the same response an unknown path gets, so the
-  // reply says nothing about what does or does not exist out there.
-  if (filePath === null) { serveIndex(); return; }
+  // own status code. It gets the byte-for-byte response an unknown path gets,
+  // so the reply says nothing about what does or does not exist out there.
+  if (filePath === null) { serveNotFound(); return; }
 
-  tryServe(filePath, serveIndex);
+  tryServe(filePath, serveNotFound);
 }).listen(port, () => {
   console.log(`Context Passport running on port ${port}`);
 });

--- a/tools/check-server.mjs
+++ b/tools/check-server.mjs
@@ -12,9 +12,16 @@
  * than fetch(), because fetch normalizes the path and would quietly test
  * nothing at all. That is the trap this file is guarding, so it has to be
  * avoided here first.
+ *
+ * It also asserts that a path which does not resolve to a file comes back as
+ * 404 rather than as the index page with a 200. Editors fetch the schema URLs
+ * on their own since SchemaStore/schemastore#6264, and a success status
+ * carrying HTML tells a validator it received a schema, which it then reports
+ * as a fault in the user's own document.
  */
 
 import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { connect } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -84,11 +91,31 @@ try {
     fail('did not serve / as html');
   }
 
+  // A miss must read as a miss. server.js used to answer every unknown path
+  // with the index page and a 200, which is the worse of the two failures for
+  // a machine: "here is your document" instead of "there is nothing here".
   const unknown = await rawRequest('/no-such-page');
-  if (unknown.startsWith('HTTP/1.1 200') && unknown.includes('text/html')) {
-    pass('unknown path falls back to index.html');
+  if (unknown.startsWith('HTTP/1.1 404')) {
+    pass('unknown path returns 404');
   } else {
-    fail('unknown path did not fall back to index.html');
+    fail('unknown path did not return 404');
+  }
+
+  // The case this file was extended for. SchemaStore points every VS Code,
+  // Visual Studio and JetBrains install at /schema/*.json, so a schema that is
+  // mistyped, renamed or not yet deployed has to come back as absent. If it
+  // comes back as HTML with a 200, the validator reports a parse failure
+  // against the user's own file and nothing points at this server.
+  const missingSchema = await rawRequest('/schema/nonexistent.json');
+  const missingSchemaBody = missingSchema.toLowerCase();
+  if (
+    missingSchema.startsWith('HTTP/1.1 404') &&
+    !missingSchemaBody.includes('text/html') &&
+    !missingSchemaBody.includes('<!doctype')
+  ) {
+    pass('missing schema path returns 404 with no HTML body');
+  } else {
+    fail('missing schema path was not a 404 with a non-HTML body');
   }
 
   // Nothing outside the site root is reachable, however the path is spelled.
@@ -129,15 +156,37 @@ try {
     }
   }
 
-  // The specification's examples reference /.well-known paths, so the rule
-  // above has to be narrower than "reject anything beginning with a dot".
-  // There is no .well-known directory yet; what matters is that the request
-  // reaches the normal miss path rather than being rejected out of hand.
-  const wellKnown = await rawRequest('/.well-known/did.json');
-  if (wellKnown.startsWith('HTTP/1.1 200') && wellKnown.includes('text/html')) {
-    pass('/.well-known is not blanket-denied');
-  } else {
-    fail('/.well-known was denied, which would block a documented path');
+  // The specification's examples reference /.well-known/did.json and
+  // /.well-known/cp-revoked-keys.json, so the deny rule above has to be
+  // narrower than "reject anything beginning with a dot".
+  //
+  // This serves a real file for the length of the check rather than asking
+  // what a missing .well-known path returns. Asking would prove nothing: a
+  // blanket-denied path and an absent one both come back 404, so the
+  // assertion would hold whether or not the rule was too broad. That is also
+  // why the earlier version of this case could not fail. Back when every miss
+  // returned the index page, a denied .well-known and a permitted one both
+  // produced 200 text/html, so it asserted a constant.
+  const wellKnownDir = join(ROOT, '.well-known');
+  const wellKnownFile = join(wellKnownDir, 'did.json');
+  const hadDir = existsSync(wellKnownDir);
+  const hadFile = existsSync(wellKnownFile);
+  try {
+    if (!hadDir) mkdirSync(wellKnownDir);
+    if (!hadFile) writeFileSync(wellKnownFile, '{"id":"did:web:contextpassport.com"}\n');
+
+    const wellKnown = await rawRequest('/.well-known/did.json');
+    const bodyOk = hadFile || wellKnown.includes('did:web:contextpassport.com');
+    if (wellKnown.startsWith('HTTP/1.1 200') && wellKnown.includes('application/json') && bodyOk) {
+      pass('/.well-known is served, not blanket-denied');
+    } else {
+      fail('/.well-known was denied, which would block a documented path');
+    }
+  } finally {
+    // Only remove what this check created, so a real .well-known directory in
+    // someone's checkout survives running the tests.
+    if (!hadFile) rmSync(wellKnownFile, { force: true });
+    if (!hadDir) rmSync(wellKnownDir, { recursive: true, force: true });
   }
 
   // A file that exists in the repo but is not part of the published site is


### PR DESCRIPTION
Closes #77.

## Was the catch all deliberate?

The issue asked this first, and the answer is no, so this removes it rather than scoping it to an `Accept` header.

`server.js` fell through to `index.html` for SPA style routing. Nothing on this site routes on the client:

```
$ grep -c "pushState\|popstate\|history.replaceState\|hashchange" index.html blog/*.html
index.html:0
blog/index.html:0
blog/the-case-for-open-audit-standards.html:0
```

Every internal link resolves to something on disk:

```
$ grep -ohE 'href="/[^"#]*"' index.html blog/*.html | sort -u
href="/"
href="/blog/"
href="/blog/the-case-for-open-audit-standards.html"
```

`/` and `/blog/` are directory requests already handled by the `index.html` branch in `tryServe`, and the third is a real file. The docs are linked to GitHub rather than served as site routes. So the fallback was not protecting a single route. It only made every mistyped, renamed or not yet deployed path report as a document that exists.

## What changed

Misses return 404 with a `text/plain` body. Paths resolving outside the root return the same bytes, so the reply still says nothing about what does or does not exist out there.

`text/plain` rather than an HTML error page, because the point is that nothing reading the content type is told it was handed a document to parse.

## Verification

The exact table from the issue, inverted:

```
path                                          status  content-type
/schema/v2-chain.json                         404    text/plain; charset=utf-8
/schema/nonexistent.json                      404    text/plain; charset=utf-8
/definitely-not-a-page                        404    text/plain; charset=utf-8
/docs/nope.md                                 404    text/plain; charset=utf-8
```

Everything that did serve still serves, unchanged:

```
/                                             200    text/html
/index.html                                   200    text/html
/blog/                                        200    text/html
/blog                                         200    text/html
/blog/the-case-for-open-audit-standards.html  200    text/html
/schema/v2.json                               200    application/json
/schema/v1.json                               200    application/json
/examples/audit.passport.json                 200    application/json
/docs/quickstart.md                           200    text/markdown
```

The new assertions fail against the old `server.js` and pass against the new one, so they are testing the fix rather than describing it:

```
$ git show origin/main:server.js > server.js && node tools/check-server.mjs
  FAIL  unknown path did not return 404
  FAIL  missing schema path was not a 404 with a non-HTML body
  2 check(s) failed.
```

Full suite:

```
$ npm test
  All examples valid: schema, recomputed hashes, and chain linkage.
  ok    unknown path returns 404
  ok    missing schema path returns 404 with no HTML body
  ok    /.well-known is served, not blanket-denied
  server.js serves the site root and nothing outside it.

$ python3 tools/check-quickstart.py
docs/quickstart.md runs as written: 5 blocks, results as documented.

$ node tools/check-quickstart-ts.mjs
docs/quickstart-typescript.md runs as written: 5 blocks, results as documented.

$ python3 examples/integrations/anthropic_sdk.py --offline
after editing step 0's output -> False
```

All six traversal cases and all four `.git` cases still pass.

## The .well-known check was asserting a constant

Worth flagging, because it changes what that case is worth rather than just adapting it.

It asserted that `/.well-known/did.json` returns `200 text/html`. There is no `.well-known` directory, so that response came from the fallback. A blanket deny would have returned `null` from `resolveWithinRoot` and hit the same fallback, producing the same `200 text/html`. The case passed whether or not the rule it was guarding was too broad.

Simply flipping it to expect 404 would have the same problem in the other direction, since a denied path and an absent one both come back 404 now.

So it creates `.well-known/did.json` for the length of the check and asserts it is served as `application/json`, then removes it. That distinguishes denied from absent, which is the property the case exists to test. It only removes what it created, so a real `.well-known` directory in someone's checkout survives running the tests.

## Not included

`npm ci` fails on the committed lockfile, which is unrelated to this change and gets its own issue rather than riding along here:

```
$ npm ci
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: @contextpassport/core@2.0.0 from lock file
npm error Missing: tsx@4.23.13 from lock file
```

CI does not hit it because every job installs with `npm install --no-save` naming packages explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkfmdezERLxFyvBZQ9vPyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkfmdezERLxFyvBZQ9vPyb)_