### PR TITLE
schema: drop verification_status, the one field that asserted rather than proved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,27 @@ breaking, which is exactly what happened in 2.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Removed
+
+- `integrity.verification_status` and `integrity.verified_at`, from
+  `schema/v2.json` and from every example, the README, Appendix A and the
+  witness-log note. Both were written unconditionally by the producer at
+  creation, covered by no hash, and `verification_status` was required, so
+  every record ever produced asserted that it had been verified and found
+  valid when nobody had verified anything. A verdict written into the record
+  it judges is the one shape of field this format exists to make unnecessary.
+  Not breaking under this file's definition: neither field was ever hashed,
+  the integrity block permits additional properties so records still carrying
+  them keep validating, and producers who omit them go from non-conforming to
+  conforming. Verifiers that need to persist a verdict keep it beside the
+  passport, never inside it.
+
+### Fixed
+
+- `tools/generate-developer-examples.py` wrote to the pre-§3.5 filenames
+  (`branch.json` rather than `branch.passport.json`), so running it after the
+  2.0.1 rename produced eight stray files beside the real examples. It now
+  emits the convention names, matching the compliance generator.
 
 ## [2.0.1] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ The goal: become the standard envelope format for AI agent events — a record a
   "integrity": {
     "payload_hash":        "sha256:e7733904...",
     "parent_hash":         "sha256:f4a2b1c3...",
-    "integrity_hash":      "sha256:8a1c9d22...",
-    "verification_status": "valid"
+    "integrity_hash":      "sha256:8a1c9d22..."
   },
   "created_at": "2026-03-29T10:00:00Z"
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -127,8 +127,7 @@ A Context Passport is a JSON object with the following structure. Fields marked 
   "integrity": {
     "payload_hash":        "sha256:hex",
     "parent_hash":         "sha256:hex | null",
-    "integrity_hash":      "sha256:hex",
-    "verification_status": "valid | broken | unverified"
+    "integrity_hash":      "sha256:hex"
   },
 
   "lineage": {
@@ -198,7 +197,8 @@ The integrity block MUST be computed by the implementation at commit time. Clien
 | `payload_hash` | SHA-256 of the canonicalized payload. See section 3.4. Formatted as `sha256:{hex}`. |
 | `parent_hash` | The `integrity_hash` of the parent commit. Null for root commits. Formatted as `sha256:{hex}` or null. |
 | `integrity_hash` | SHA-256 of the concatenation of `payload_hash` and `parent_hash`. See section 3.4. |
-| `verification_status` | `valid` if the chain is intact to this point. `broken` if a hash mismatch is detected. `unverified` if verification has not been performed. |
+
+The integrity block carries no verdict about itself. Whether a chain is intact is a conclusion the verifier reaches by recomputing these hashes, never a fact the producer records. Earlier drafts included a `verification_status` field here; it was written unconditionally at creation, covered by no hash, and therefore stated nothing a reader could rely on. Verifiers that need to persist a verdict should do so in their own metadata, outside the passport.
 
 #### 3.2.6 Lineage
 
@@ -482,7 +482,6 @@ def make_passport(agent_id, agent_name, payload, parent=None,
             "payload_hash":        pay_hash,
             "parent_hash":         parent_hash,
             "integrity_hash":      int_hash,
-            "verification_status": "valid",
         },
         "lineage": {
             "fork_of":      None,

--- a/docs/witness-log.md
+++ b/docs/witness-log.md
@@ -43,7 +43,7 @@ A passport progresses through these tiers in order. Different verifiers care abo
 The receiving server accepts passports from clients (per `docs/throughput-and-trust.md` submission patterns), validates them, and stores them. Required validation at this tier:
 
 - **Schema validation:** the incoming passport validates against the schema matching its `schema_version` (`schema/v2.json` for v2.0 records, `schema/v1.json` for v1.x records).
-- **Hash validation:** `integrity.payload_hash` recomputed by the server matches the client-supplied value. If not, the passport is stored but flagged with `verification_status: rejected` and the reason recorded.
+- **Hash validation:** `integrity.payload_hash` recomputed by the server matches the client-supplied value. If not, the passport is stored unmodified but flagged as rejected in the operator's own metadata, with the reason recorded. The flag lives beside the passport, never inside it: the envelope carries no field for a verdict, because a verdict written into the record it judges is worth nothing.
 - **Chain validation:** if `parent_id` is set, the parent passport is fetched and `integrity.parent_hash` is verified to match its `integrity_hash`. Broken chains are flagged but stored.
 - **Signature validation (if present):** the Ed25519 (or other algorithm) signature is verified against the embedded public key. Failures are flagged but stored.
 

--- a/examples/audit.passport.json
+++ b/examples/audit.passport.json
@@ -51,8 +51,7 @@
   "integrity": {
     "payload_hash": "sha256:1e3a9606447071ca624fe3e18a5b800f0c7013f3ff00160dbd95340c5811604b",
     "parent_hash": null,
-    "integrity_hash": "sha256:ce8c1e8b8cf507e9af03d9c432e95fecc149009a9854251580692202c57638b9",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:ce8c1e8b8cf507e9af03d9c432e95fecc149009a9854251580692202c57638b9"
   },
   "created_at": "2026-04-30T23:59:00Z"
 }

--- a/examples/branch.passport.json
+++ b/examples/branch.passport.json
@@ -29,8 +29,7 @@
   "integrity": {
     "payload_hash": "sha256:17a4e721b08159c0e7e901ac24929731ee651406c105132fd0ddf0498adbc63c",
     "parent_hash": null,
-    "integrity_hash": "sha256:d1b22b0c4222148bcfabd8aff5a73ec3a2b77b154943d087a18bb37c01093bf4",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:d1b22b0c4222148bcfabd8aff5a73ec3a2b77b154943d087a18bb37c01093bf4"
   },
   "created_at": "2026-03-29T10:32:00Z"
 }

--- a/examples/chained.passports.json
+++ b/examples/chained.passports.json
@@ -32,9 +32,7 @@
     "integrity": {
       "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
       "parent_hash": null,
-      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
-      "verification_status": "valid",
-      "verified_at": "2026-03-29T10:00:00Z"
+      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09"
     },
     "created_at": "2026-03-29T10:00:00Z"
   },
@@ -76,9 +74,7 @@
     "integrity": {
       "payload_hash": "sha256:0108fdadbad542e6b59c86f3c4eb05669dd84ba5d84b7601fdffde7b344d6b5d",
       "parent_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
-      "integrity_hash": "sha256:44350101059afdf7ac0222e271ada4cfc04ccb0a617eddd5caabaacea08a162d",
-      "verification_status": "valid",
-      "verified_at": "2026-03-29T10:12:30Z"
+      "integrity_hash": "sha256:44350101059afdf7ac0222e271ada4cfc04ccb0a617eddd5caabaacea08a162d"
     },
     "created_at": "2026-03-29T10:12:30Z"
   },
@@ -119,9 +115,7 @@
     "integrity": {
       "payload_hash": "sha256:3eb2fcd7fa14ffc8b7bab54667ffdc68263da2e403ac0ddfe78065adb0f8b34f",
       "parent_hash": "sha256:44350101059afdf7ac0222e271ada4cfc04ccb0a617eddd5caabaacea08a162d",
-      "integrity_hash": "sha256:b884301cb2a7d1722095760806b502bd3ac4aaf034bfb58d67185bc4287acae5",
-      "verification_status": "valid",
-      "verified_at": "2026-03-29T10:31:00Z"
+      "integrity_hash": "sha256:b884301cb2a7d1722095760806b502bd3ac4aaf034bfb58d67185bc4287acae5"
     },
     "created_at": "2026-03-29T10:31:00Z"
   }

--- a/examples/consent.passport.json
+++ b/examples/consent.passport.json
@@ -36,8 +36,7 @@
   "integrity": {
     "payload_hash": "sha256:f874055832b8c16b168517871f7d5a8282ea61a5b8870bb2be72a6be317b15fa",
     "parent_hash": null,
-    "integrity_hash": "sha256:4a2acafe5b7191946edc773b38126a294d8857fe4377c7dae635e8d98277f3e0",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:4a2acafe5b7191946edc773b38126a294d8857fe4377c7dae635e8d98277f3e0"
   },
   "created_at": "2026-03-29T09:55:00Z"
 }

--- a/examples/error.passport.json
+++ b/examples/error.passport.json
@@ -34,8 +34,7 @@
   "integrity": {
     "payload_hash": "sha256:713553eb9558b54ce9ec26de197d00de620ff73bf3499ef1b0b4a874eee24cb8",
     "parent_hash": null,
-    "integrity_hash": "sha256:95cea4ee43f62ee7a614daa091a34751b9b00478cb961e6b4597b602e109d254",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:95cea4ee43f62ee7a614daa091a34751b9b00478cb961e6b4597b602e109d254"
   },
   "created_at": "2026-03-29T10:05:00Z"
 }

--- a/examples/escalate.passports.json
+++ b/examples/escalate.passports.json
@@ -31,8 +31,7 @@
     "integrity": {
       "payload_hash": "sha256:c921d9285c70b5c47db8e6f28e88b5270d2cc9f71a09c47bd2f6f83bdc432a52",
       "parent_hash": null,
-      "integrity_hash": "sha256:7a180dd4111748da065ad771625af21732064deeadb293b2e922ad19244c4b33",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:7a180dd4111748da065ad771625af21732064deeadb293b2e922ad19244c4b33"
     },
     "created_at": "2026-03-29T11:00:00Z"
   },
@@ -69,8 +68,7 @@
     "integrity": {
       "payload_hash": "sha256:bb5b03b8aac0f5d45f7585005e05b8ff93f11de5aed52fb4fc5d434f3a348079",
       "parent_hash": "sha256:7a180dd4111748da065ad771625af21732064deeadb293b2e922ad19244c4b33",
-      "integrity_hash": "sha256:2e362f8513193b558672604d639732d0e6e201f58e1a607ebcbe11c89ec04755",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:2e362f8513193b558672604d639732d0e6e201f58e1a607ebcbe11c89ec04755"
     },
     "created_at": "2026-03-29T11:01:00Z"
   }

--- a/examples/fork.passports.json
+++ b/examples/fork.passports.json
@@ -36,8 +36,7 @@
     "integrity": {
       "payload_hash": "sha256:3eb2fcd7fa14ffc8b7bab54667ffdc68263da2e403ac0ddfe78065adb0f8b34f",
       "parent_hash": null,
-      "integrity_hash": "sha256:5364f59ce76fd24f8c251000a85ee3d67da710fd9fa46895d1b926a3a8a7d7a1",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:5364f59ce76fd24f8c251000a85ee3d67da710fd9fa46895d1b926a3a8a7d7a1"
     },
     "created_at": "2026-03-29T10:31:00Z"
   },
@@ -71,8 +70,7 @@
     "integrity": {
       "payload_hash": "sha256:4a33009be77f1b0f163a8cf59d2a7961172ba4b7280848a5ede393267be60324",
       "parent_hash": "sha256:5364f59ce76fd24f8c251000a85ee3d67da710fd9fa46895d1b926a3a8a7d7a1",
-      "integrity_hash": "sha256:6894224dc6dcbe421aa73fea808155db22f23f91ed36f8ce2553bf653be1ec53",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:6894224dc6dcbe421aa73fea808155db22f23f91ed36f8ce2553bf653be1ec53"
     },
     "created_at": "2026-03-29T10:33:00Z"
   }

--- a/examples/merge.passports.json
+++ b/examples/merge.passports.json
@@ -32,8 +32,7 @@
     "integrity": {
       "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
       "parent_hash": null,
-      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09"
     },
     "created_at": "2026-03-29T10:00:00Z"
   },
@@ -66,8 +65,7 @@
     "integrity": {
       "payload_hash": "sha256:5668c768bace5b0b95e3ff3ffabd4950033929f710fb4d5beea245df1ed1bc39",
       "parent_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
-      "integrity_hash": "sha256:c1360cfaedda31143bf0be502f3acb02cfa779767772a1d68c605b89c1bd8a59",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:c1360cfaedda31143bf0be502f3acb02cfa779767772a1d68c605b89c1bd8a59"
     },
     "created_at": "2026-03-29T10:35:00Z"
   },
@@ -102,8 +100,7 @@
     "integrity": {
       "payload_hash": "sha256:445713597279c490a18da0362b0a1ae4907ea9f891f8fc73e43c61fd8574500c",
       "parent_hash": "sha256:c1360cfaedda31143bf0be502f3acb02cfa779767772a1d68c605b89c1bd8a59",
-      "integrity_hash": "sha256:258bc5bd7ad87a5181e7db764075a57eade7bbb7b835a1dc3edda53ec2cfdef4",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:258bc5bd7ad87a5181e7db764075a57eade7bbb7b835a1dc3edda53ec2cfdef4"
     },
     "created_at": "2026-03-29T10:36:00Z"
   }

--- a/examples/override.passports.json
+++ b/examples/override.passports.json
@@ -33,8 +33,7 @@
     "integrity": {
       "payload_hash": "sha256:43e955f6b5f542a18de59064a5a90e28496cdfd7f4f3e534344f0a72e22536ac",
       "parent_hash": null,
-      "integrity_hash": "sha256:f732a2d8020bb8649b0fb0764ec7ab1f9af40279562414ff77cb96e83629717e",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:f732a2d8020bb8649b0fb0764ec7ab1f9af40279562414ff77cb96e83629717e"
     },
     "created_at": "2026-03-29T10:01:00Z"
   },
@@ -72,8 +71,7 @@
     "integrity": {
       "payload_hash": "sha256:f12f6d7c3634860aabfec98a63bd567792baa6c54d1f17396fbe9b218089a7f2",
       "parent_hash": "sha256:f732a2d8020bb8649b0fb0764ec7ab1f9af40279562414ff77cb96e83629717e",
-      "integrity_hash": "sha256:e8933c7737e077e9539682e0e8829600425d94ff4ca4e47af5fe461738ecac41",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:e8933c7737e077e9539682e0e8829600425d94ff4ca4e47af5fe461738ecac41"
     },
     "created_at": "2026-03-29T10:02:00Z"
   }

--- a/examples/redact.passport.json
+++ b/examples/redact.passport.json
@@ -34,8 +34,7 @@
   "integrity": {
     "payload_hash": "sha256:cd8de10b0635d04a1a00aec06b314b3785841db2c4afbf8143c8fa350b893a31",
     "parent_hash": null,
-    "integrity_hash": "sha256:c081787709c24f5dea4cd8f9793d0f30a7f45382a6b6bac5017bbb0e4990e819",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:c081787709c24f5dea4cd8f9793d0f30a7f45382a6b6bac5017bbb0e4990e819"
   },
   "created_at": "2026-04-28T14:30:00Z"
 }

--- a/examples/retry.passport.json
+++ b/examples/retry.passport.json
@@ -35,8 +35,7 @@
   "integrity": {
     "payload_hash": "sha256:af1da6740ef7fe51c2825a256e16f6016e83e2d7538fd191f378f91c868003f1",
     "parent_hash": null,
-    "integrity_hash": "sha256:d6b096a85574cd6ff18777ccb169c99a38a8dfd3bb286021ae5ccd19ed5cd273",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:d6b096a85574cd6ff18777ccb169c99a38a8dfd3bb286021ae5ccd19ed5cd273"
   },
   "created_at": "2026-03-29T10:08:00Z"
 }

--- a/examples/revert.passports.json
+++ b/examples/revert.passports.json
@@ -30,8 +30,7 @@
     "integrity": {
       "payload_hash": "sha256:60204ae61e367079befcecefb1e2c30e96c5eac0aaf39a1e012225455fb059a8",
       "parent_hash": null,
-      "integrity_hash": "sha256:282bdc85e3ced5b9b5ac4ddc33d681811918a417bc2b69fce2f23748f47b4976",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:282bdc85e3ced5b9b5ac4ddc33d681811918a417bc2b69fce2f23748f47b4976"
     },
     "created_at": "2026-03-29T10:12:30Z"
   },
@@ -65,8 +64,7 @@
     "integrity": {
       "payload_hash": "sha256:d57d6ac2decd245e4d2757c85a4fc669863101f129faa12789118ea3c9c22ae0",
       "parent_hash": "sha256:282bdc85e3ced5b9b5ac4ddc33d681811918a417bc2b69fce2f23748f47b4976",
-      "integrity_hash": "sha256:da1f660badc3692c0e97123d389764f14eced93c8fcc2e998f0536bc875edcd9",
-      "verification_status": "valid"
+      "integrity_hash": "sha256:da1f660badc3692c0e97123d389764f14eced93c8fcc2e998f0536bc875edcd9"
     },
     "created_at": "2026-03-29T10:34:00Z"
   }

--- a/examples/signed.passport.json
+++ b/examples/signed.passport.json
@@ -31,9 +31,7 @@
   "integrity": {
     "payload_hash": "sha256:5c0f1239de654ec7231d7c1f29788ab31112bde0dbae55635e0d2cf4e9050246",
     "parent_hash": null,
-    "integrity_hash": "sha256:023d12cccdb6611f57038dd2174765f362b3feace7fb8df2f0813b637493168a",
-    "verification_status": "valid",
-    "verified_at": "2026-03-29T11:00:00Z"
+    "integrity_hash": "sha256:023d12cccdb6611f57038dd2174765f362b3feace7fb8df2f0813b637493168a"
   },
   "created_at": "2026-03-29T11:00:00Z",
   "signature": {

--- a/examples/single-commit.passport.json
+++ b/examples/single-commit.passport.json
@@ -31,9 +31,7 @@
   "integrity": {
     "payload_hash": "sha256:89d60bc4150c0f0401e73986b473f50e0fabf12504429190c25b72ae05f3021a",
     "parent_hash": null,
-    "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09",
-    "verification_status": "valid",
-    "verified_at": "2026-03-29T10:00:00Z"
+    "integrity_hash": "sha256:94c80e78dbfaf8f23623dfc1f1a250c9ce4ef21b8fc5dcb9394a11db42b9cd09"
   },
   "created_at": "2026-03-29T10:00:00Z"
 }

--- a/examples/spawn.passport.json
+++ b/examples/spawn.passport.json
@@ -37,8 +37,7 @@
   "integrity": {
     "payload_hash": "sha256:d94802bf53799d6617a0f2712ea555ce74d709f836617483c1d5510947c1b501",
     "parent_hash": null,
-    "integrity_hash": "sha256:815f92fdc28ed28981b798476c8d76b0618b82380ae294b51227bdb8e0477d9c",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:815f92fdc28ed28981b798476c8d76b0618b82380ae294b51227bdb8e0477d9c"
   },
   "created_at": "2026-03-29T10:06:00Z"
 }

--- a/examples/timeout.passport.json
+++ b/examples/timeout.passport.json
@@ -34,8 +34,7 @@
   "integrity": {
     "payload_hash": "sha256:27638e9a50676792faec8ac240374e5ce1789d25a2846a10fc87e3622abb3689",
     "parent_hash": null,
-    "integrity_hash": "sha256:79f87b18d7f2f5537d9554e9099b9521a0ee77ad83cf9a914877cb68b44483a1",
-    "verification_status": "valid"
+    "integrity_hash": "sha256:79f87b18d7f2f5537d9554e9099b9521a0ee77ad83cf9a914877cb68b44483a1"
   },
   "created_at": "2026-03-29T10:07:00Z"
 }

--- a/examples/with-extensions.passport.json
+++ b/examples/with-extensions.passport.json
@@ -26,9 +26,7 @@
   "integrity": {
     "payload_hash": "sha256:0ffa7a47f84b1808822fde9ad7b9ecfff5cc75dd15e572fe25bc022b2970b781",
     "parent_hash": null,
-    "integrity_hash": "sha256:e76998e3108365887fec3674c5d0edfdaeca57d5a83971ffb552d0440b83bb14",
-    "verification_status": "valid",
-    "verified_at": "2026-03-29T11:10:00Z"
+    "integrity_hash": "sha256:e76998e3108365887fec3674c5d0edfdaeca57d5a83971ffb552d0440b83bb14"
   },
   "created_at": "2026-03-29T11:10:00Z",
   "extensions": {

--- a/schema/v2.json
+++ b/schema/v2.json
@@ -69,7 +69,7 @@
     },
     "integrity": {
       "type": "object",
-      "required": ["payload_hash", "integrity_hash", "verification_status"],
+      "required": ["payload_hash", "integrity_hash"],
       "properties": {
         "payload_hash": {
           "type": "string",
@@ -85,12 +85,7 @@
           "type": "string",
           "pattern": "^sha256:[a-f0-9]{64}$",
           "description": "sha256(payload_hash + parent_hash)"
-        },
-        "verification_status": {
-          "type": "string",
-          "enum": ["valid", "broken", "unverified"]
-        },
-        "verified_at": { "type": ["string", "null"], "format": "date-time" }
+        }
       }
     },
     "lineage": {

--- a/tools/generate-compliance-examples.py
+++ b/tools/generate-compliance-examples.py
@@ -55,8 +55,11 @@ def pin(passport, *, ctx_id, timestamp):
     passport["id"] = ctx_id
     passport["created_at"] = timestamp
     passport["event"]["timestamp"] = timestamp
-    if passport["integrity"].get("verified_at") is not None:
-        passport["integrity"]["verified_at"] = timestamp
+    # The SDK still emits verification_status and verified_at. The schema no
+    # longer defines either, so strip rather than pin: the examples should show
+    # the shape the specification describes, not the shape one SDK produces.
+    passport["integrity"].pop("verification_status", None)
+    passport["integrity"].pop("verified_at", None)
     return passport
 
 

--- a/tools/generate-developer-examples.py
+++ b/tools/generate-developer-examples.py
@@ -67,8 +67,11 @@ def pin(passport, *, ctx_id, timestamp):
     passport["id"] = ctx_id
     passport["created_at"] = timestamp
     passport["event"]["timestamp"] = timestamp
-    if passport["integrity"].get("verified_at") is not None:
-        passport["integrity"]["verified_at"] = timestamp
+    # The SDK still emits verification_status and verified_at. The schema no
+    # longer defines either, so strip rather than pin: the examples should show
+    # the shape the specification describes, not the shape one SDK produces.
+    passport["integrity"].pop("verification_status", None)
+    passport["integrity"].pop("verified_at", None)
     return passport
 
 
@@ -108,7 +111,7 @@ error = pin(
     ctx_id="ctx_1774358320000_e1a2b3c4d5e6",
     timestamp="2026-03-29T10:05:00Z",
 )
-write("error.json", error)
+write("error.passport.json", error)
 
 
 # ------------------------------------------------------------------- spawn
@@ -138,7 +141,7 @@ spawn = pin(
     ctx_id="ctx_1774358330000_a1b2c3d4e5f7",
     timestamp="2026-03-29T10:06:00Z",
 )
-write("spawn.json", spawn)
+write("spawn.passport.json", spawn)
 
 
 # ----------------------------------------------------------------- timeout
@@ -165,7 +168,7 @@ timeout = pin(
     ctx_id="ctx_1774358340000_f1e2d3c4b5a6",
     timestamp="2026-03-29T10:07:00Z",
 )
-write("timeout.json", timeout)
+write("timeout.passport.json", timeout)
 
 
 # ------------------------------------------------------------------ branch
@@ -190,7 +193,7 @@ branch = pin(
     ctx_id="ctx_1774358470000_b1a2c3d4e5f8",
     timestamp="2026-03-29T10:32:00Z",
 )
-write("branch.json", branch)
+write("branch.passport.json", branch)
 
 
 # ------------------------------------------------------------------- retry
@@ -218,7 +221,7 @@ retry = pin(
     ctx_id="ctx_1774358355000_c1d2e3f4a5b6",
     timestamp="2026-03-29T10:08:00Z",
 )
-write("retry.json", retry)
+write("retry.passport.json", retry)
 
 
 # ------------------------------------------------------------------- fork
@@ -269,7 +272,7 @@ fork_event = pin(
     timestamp="2026-03-29T10:33:00Z",
 )
 relink(fork_event, fork_checkpoint)
-write("fork.json", [fork_checkpoint, fork_event])
+write("fork.passports.json", [fork_checkpoint, fork_event])
 
 
 # ----------------------------------------------------------------- revert
@@ -312,7 +315,7 @@ revert_event = pin(
     timestamp="2026-03-29T10:34:00Z",
 )
 relink(revert_event, revert_commit)
-write("revert.json", [revert_commit, revert_event])
+write("revert.passports.json", [revert_commit, revert_event])
 
 
 # ------------------------------------------------------------------ merge
@@ -378,6 +381,6 @@ merge_event = pin(
     timestamp="2026-03-29T10:36:00Z",
 )
 relink(merge_event, merge_branch_work)
-write("merge.json", [merge_ancestor, merge_branch_work, merge_event])
+write("merge.passports.json", [merge_ancestor, merge_branch_work, merge_event])
 
 print("\nRun `npm test` to validate these against schema/v2.json.")


### PR DESCRIPTION
Removes `integrity.verification_status` and `integrity.verified_at` from the schema, the spec, the README, Appendix A, the witness-log note, both generators, and all 17 examples.

## Why

Every field in a passport is one of two things: data, or a verifiable derivation of data. `verification_status` was the sole exception. It was:

- **required** by `schema/v2.json`
- **enumerated** `valid | broken | unverified`
- **hardcoded** to `"valid"` by both reference SDKs at creation time
- **covered by no hash.** §3.4 hashes `payload_hash + parent_hash` only

So every record ever produced asserted that it had been verified and found valid, when nobody had verified anything. `verified_at` carried a timestamp for the verification that never happened.

The failure mode is precise. Edit a payload and `payload_hash` stops matching, which the chain detects. But `verification_status` still says `valid`, and `verified_at` still carries a plausible time. A consumer who reads the field rather than recomputing gets exactly the wrong answer, confidently, from inside the block named `integrity`.

A verdict written into the record it judges is the one shape of field this format exists to make unnecessary. With it gone, the invariant is stateable in one sentence: **every field is data or a verifiable derivation of data.** Today that sentence is false. After this it is true.

`docs/witness-log.md` was also using `verification_status: rejected`, a value not in the enum, which is its own small evidence that the field had no stable meaning.

## Not breaking, checked three ways

Under `CHANGELOG.md`'s definition (the bytes that get hashed), and beyond it:

1. **No hash moves.** Neither field was ever an input to any hash. All 25 records across the 17 examples reproduce their committed `payload_hash`, `parent_hash` and `integrity_hash` exactly. The diff on `examples/` is the 28 removed lines and their trailing commas, nothing else.
2. **Old records still validate.** The integrity block does not set `additionalProperties: false`, so a record still carrying either field validates as an unrecognised extra property. `npm test` passes on all 17.
3. **Pure relaxation.** Producers who omit the fields go from non-conforming to conforming. Producers who include them stay conforming. The set of valid records strictly widens, so nothing anywhere can break.

That is the same shape as #42, a MUST to SHOULD that was ruled editorial on the test of whether any conforming implementation changes behaviour. None does here.

## Also fixed while in the generators

`tools/generate-developer-examples.py` still wrote to the pre-§3.5 filenames (`branch.json` rather than `branch.passport.json`). The compliance generator was updated in 2.0.1; this one was not, and nobody had run it since. The first run produced eight stray files beside the real examples. Both generators now emit the convention names.

## Follow-ups, not in this PR

- Both SDKs still emit the fields. Harmless (see point 2) but untidy. Issues to follow on `typescript` and `python`.
- `schema/v1.json` is untouched. It is retained frozen for verifying v1.x records and should stay exactly as those records were written against.

## Editorial or substantive

Touches `schema/v2.json` and `SPEC.md`, so it is the owner's to merge. My read is editorial by the #42 test, since no conforming implementation changes behaviour and the valid set only widens. If you would rather run the 14 day window regardless, #48 is already in that queue and they could share it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
