### PR TITLE
docs: say what the chain protects, and show what it does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,19 @@ breaking, which is exactly what happened in 2.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- §5.4 no longer claims that records "cannot be modified, reordered, or
+  backdated without detection". Under the 2.0 hash rules that is true of the
+  payload and the chain order and false of everything else: `created_by`,
+  `event`, `trace_id` and `branch_key` are carried by the chain but not bound
+  by it, so an unsigned record can be reattributed, reclassified or backdated
+  and still verify. Tested against both reference SDKs. The section now says
+  what the chain protects, what only a signature protects, and that integrators
+  who care about attribution or timing MUST sign. Both quickstarts gain a
+  section 5 demonstrating the gap, so a reader who has just watched a payload
+  edit break verification also watches an author edit fail to. Binding the
+  envelope into the chain is proposed for 3.0 in #81.
 
 ## [2.0.1] - 2026-08-28
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -348,7 +348,7 @@ The `created_by.agent_id` field is self-reported by the committing agent. It is 
 
 ### 5.4 Completeness vs. integrity
 
-This specification provides guarantees about the **integrity** of records that are created — they cannot be modified, reordered, or backdated without detection. It does not and cannot guarantee **completeness** — that every event the agent should have recorded was in fact recorded. A client who controls record creation can omit records they choose not to create, and no cryptographic system can reveal the omission.
+This specification provides guarantees about the **integrity** of the payload and the chain linkage of records that are created: the payload cannot be modified, and records cannot be reordered, without detection. Under the 2.0 hash rules (§3.4) the envelope fields are carried by the chain but not bound by it. `created_by`, `event`, `trace_id` and `branch_key` can be rewritten on an unsigned record and the chain still verifies; backdating in particular is a change to `event.timestamp` and is not detected by the chain alone. Those fields are bound only when the record is signed (§3.2.7) and the verifier checks the signature. Integrators for whom attribution or timing matters, which includes every compliance use, MUST sign. It does not and cannot guarantee **completeness** — that every event the agent should have recorded was in fact recorded. A client who controls record creation can omit records they choose not to create, and no cryptographic system can reveal the omission.
 
 Implementations and integrators that require completeness guarantees (e.g., regulated audit trails) MUST combine Context Passport with one or more of:
 

--- a/docs/quickstart-typescript.md
+++ b/docs/quickstart-typescript.md
@@ -96,6 +96,27 @@ Put it back and it verifies again:
 console.log(verifyChain(chain));
 ```
 
+## 5. What the chain does not protect
+
+The chain covers the payload and the link to the parent. It does not cover
+who wrote the record, when, or what kind of event it was. Rewrite the author:
+
+```typescript
+chain[0].created_by.agent_id = "someone-else";
+
+console.log(verifyChain(chain));
+```
+
+`true`. The attribution changed and nothing noticed. The same is true of
+`event.type`, `event.timestamp` and `event.to_agent_id`: under the 2.0 hash
+rules those fields are metadata the chain carries but does not bind.
+
+If who and when matter to you, and for any compliance use they do, sign the
+records. A signature covers the whole envelope, so a forged author fails
+`verifySignature` even though it passes `verifyChain`. Signing is covered in
+[`docs/key-management.md`](key-management.md). Binding the envelope into the
+chain itself is proposed for 3.0.
+
 ## Where to go next
 
 - [`examples/`](../examples) has worked records for each event type, including

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,6 +96,27 @@ chain[0]["payload"]["output"]["decision"] = "decline"
 print(verify_chain(chain))
 ```
 
+## 5. What the chain does not protect
+
+The chain covers the payload and the link to the parent. It does not cover
+who wrote the record, when, or what kind of event it was. Rewrite the author:
+
+```python
+chain[0]["created_by"]["agent_id"] = "someone-else"
+
+print(verify_chain(chain))
+```
+
+`True`. The attribution changed and nothing noticed. The same is true of
+`event.type`, `event.timestamp` and `event.to_agent_id`: under the 2.0 hash
+rules those fields are metadata the chain carries but does not bind.
+
+If who and when matter to you, and for any compliance use they do, sign the
+records. A signature covers the whole envelope, so a forged author fails
+`verify_signature` even though it passes `verify_chain`. Signing is covered in
+[`docs/key-management.md`](key-management.md). Binding the envelope into the
+chain itself is proposed for 3.0.
+
 ## Where to go next
 
 - [`examples/`](../examples) has worked records for each event type, including

--- a/tools/check-quickstart-ts.mjs
+++ b/tools/check-quickstart-ts.mjs
@@ -22,7 +22,9 @@ const DOC = join(ROOT, "docs", "quickstart-typescript.md");
 
 // The boolean lines the document tells the reader to expect, in order:
 //   parent_hash linkage, verify, verify after tampering, verify after undo.
-const EXPECTED_BOOLS = ["true", "true", "false", "true"];
+//   ...then the author is rewritten and the chain still verifies, which is the
+//   document's honest statement of what the 2.0 chain does not cover.
+const EXPECTED_BOOLS = ["true", "true", "false", "true", "true"];
 
 const blocks = [...readFileSync(DOC, "utf8").replace(/\r\n/g, "\n").matchAll(/```typescript\n(.*?)```/gs)].map((m) => m[1]);
 if (blocks.length === 0) {

--- a/tools/check-quickstart.py
+++ b/tools/check-quickstart.py
@@ -25,7 +25,9 @@ DOC = ROOT / "docs" / "quickstart.md"
 
 # The boolean lines the document tells the reader to expect, in order:
 #   parent_hash linkage, verify, verify after tampering, verify after undo.
-EXPECTED_BOOLS = ["True", "True", "False", "True"]
+#   ...then the author is rewritten and the chain still verifies, which is the
+#   document's honest statement of what the 2.0 chain does not cover.
+EXPECTED_BOOLS = ["True", "True", "False", "True", "True"]
 
 blocks = re.findall(r"```python\n(.*?)```", io.open(DOC, encoding="utf-8").read(), re.S)
 if not blocks:


### PR DESCRIPTION
Tier 1 of three. Corrects a false normative claim and shows readers the gap it was hiding. Touches `SPEC.md`, so it is the owner's to merge.

## The claim

§5.4, until this PR:

> they cannot be modified, reordered, or backdated without detection

Tested against both reference SDKs on a verified chain, one field edit at a time:

| Edit | `verify_chain` |
|---|---|
| `payload.output` | detected |
| `created_by.agent_id` | **passes** |
| `event.type`, `commit` → `override` | **passes** |
| `event.timestamp`, backdated a year | **passes** |
| `event.to_agent_id` | **passes** |
| `trace_id`, `branch_key`, `id`, `parent_id` | **passes** |

§3.4 hashes `payload_hash + parent_hash` and nothing else. Backdating is an edit to `event.timestamp` and the chain cannot see it. The claim is false for every unsigned record.

## What changes

**§5.4** now says what is actually bound (payload, chain order), what is carried but not bound (the envelope), that a signature is what binds the envelope, and that integrators who care about attribution or timing MUST sign. The completeness paragraph after it is untouched.

**Both quickstarts gain a section 5.** The existing tamper demo edits `payload.output`, shows `False`, and a reader reasonably infers that editing anything would. Section 5 edits `created_by.agent_id` and shows `True`, then explains why and points at signing. That second demonstration is the missing one. Its absence is precisely how a reader walks away believing a guarantee that does not exist.

**Both checkers** now expect the extra boolean. Verified locally:

```
docs/quickstart.md runs as written: 6 blocks, results as documented.
docs/quickstart-typescript.md runs as written: 6 blocks, results as documented.
```

## What this does not do

It does not close the gap. Nothing in this PR changes a hashed byte. It stops the specification promising something it does not deliver, which is the dangerous part today: an adopter who believes §5.4 will build a compliance system on attribution the chain does not protect.

The other two tiers, filed alongside:

- **Tier 2**, SDK PRs on `python` and `typescript`: `verify_chain` consults the signature when one is present, closing the signed-but-reports-valid hole through the API people actually call.
- **Tier 3**, RFC #81: bind the envelope into the integrity hash in 3.0. The only tier that protects unsigned records.

## Editorial or substantive

Correcting a false statement about existing behaviour, with no change to any hashed byte or any conforming implementation, is editorial by the #42 test. The new MUST on signing for compliance use is stating a consequence of the existing design rather than adding a requirement, but if you read it as substantive it can share #81's window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
