### PR TITLE
ci: install from the lockfile, so it is exercised rather than bypassed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '20'
-      - run: npm install --no-save ajv ajv-formats canonicalize
+          cache: npm
+      # npm ci, not npm install --no-save with a package list. Naming packages
+      # here meant the lockfile was never read, so it drifted out of sync with
+      # package.json and nothing went red until someone tried npm ci by hand
+      # (#79). It also kept the dependency list in two places. This installs
+      # what package.json declares, and fails if the lockfile disagrees.
+      - run: npm ci
       - run: node tools/validate-examples.mjs
       # server.js serves contextpassport.com. It previously joined the raw
       # request path onto the site root with no containment check, which made
@@ -87,5 +93,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '20'
-      - run: npm install --no-save @contextpassport/core@^2.0.0 tsx
+          cache: npm
+      # See the note in the examples job: npm ci so the lockfile is exercised
+      # rather than bypassed. @contextpassport/core and tsx are both in
+      # devDependencies, so this installs them without naming them again.
+      - run: npm ci
       - run: node tools/check-quickstart-ts.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,13 @@ breaking, which is exactly what happened in 2.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- `package-lock.json` was out of sync with `package.json`, so `npm ci` failed
+  on a clean checkout (#79, fixed in #83). CI never noticed because every job
+  installed by naming packages with `--no-save`, which reads nothing from the
+  lockfile. Both jobs now run `npm ci`, so the lockfile is exercised on every
+  run and the dependency list lives only in `package.json`.
 
 ## [2.0.1] - 2026-08-28
 


### PR DESCRIPTION
Follow-up to #83, which regenerated `package-lock.json`. This makes CI actually read it.

## Why

Your #79 made the point precisely:

> Why CI does not catch it: every job installs by naming packages explicitly rather than reading the lockfile

That is still true after #83. Both jobs ran `npm install --no-save <list>`, so the lockfile was committed, correct as of today, and never once checked. It could drift again tomorrow and nothing would go red until somebody tried `npm ci` by hand.

It also duplicated the dependency list. All five packages are declared in `package.json` under `devDependencies`; naming them again in two workflow steps meant maintaining the same information twice and checking only one copy.

## What changes

Both jobs now run `npm ci`. That installs exactly what the lockfile pins, and **fails if the lockfile disagrees with package.json**, which is the property that was missing.

Also adds `cache: npm` to both `setup-node` steps, which only becomes useful once there is a lockfile worth keying a cache on.

## Verified locally

```
$ npm ci     → ok
$ npm test   → ok
$ node tools/check-quickstart-ts.mjs
docs/quickstart-typescript.md runs as written: 5 blocks, results as documented.
```

The TypeScript checker is the one that matters here: it needs `@contextpassport/core` and `tsx`, which the job previously installed by name and now gets from the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)